### PR TITLE
chore: make container test tooling engine-agnostic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,17 +99,21 @@ pytest-coverage:
 	@echo "Running pytest with coverage..."
 	@$(PYTEST_BIN) --cov=src --cov=scripts --cov-report=term-missing
 
-# Build Docker image
+# Resolve which container engine to use. Prefer podman when present,
+# otherwise docker. Override with `make docker-test CONTAINER_ENGINE=docker`.
+CONTAINER_ENGINE ?= $(shell command -v podman >/dev/null 2>&1 && echo podman || echo docker)
+
+# Build container image
 docker-build:
-	docker build -t antsaibot .
+	$(CONTAINER_ENGINE) build -t antsaibot .
 
-# Run tests in Docker
+# Run tests in a container
 docker-test:
-	docker run --rm -v $(PWD)/game_logs:/app/game_logs antsaibot make test
+	$(CONTAINER_ENGINE) run --rm -v $(PWD)/game_logs:/app/game_logs antsaibot make test
 
-# Run interactive Docker container
+# Run interactive container
 docker-run:
-	docker run -it --rm -v $(PWD):/app -w /app antsaibot /bin/bash
+	$(CONTAINER_ENGINE) run -it --rm -v $(PWD):/app -w /app antsaibot /bin/bash
 
 # Quick test (30 turns, 2 players)
 test:

--- a/scripts/docker_test.sh
+++ b/scripts/docker_test.sh
@@ -16,14 +16,18 @@ IMAGE_NAME="antsaibot"
 CONTAINER_NAME="antsaibot-test"
 LOG_DIR="game_logs"
 
+# Resolve which container engine to use. Prefer podman when present,
+# otherwise docker. Override by exporting CONTAINER_ENGINE=docker.
+ENGINE="${CONTAINER_ENGINE:-$(command -v podman >/dev/null 2>&1 && echo podman || echo docker)}"
+
 echo -e "${BLUE}AntsAIBot Docker Testing${NC}"
 echo "========================="
 echo ""
 
 # Function to check if Docker is running
 check_docker() {
-    if ! docker info >/dev/null 2>&1; then
-        echo -e "${RED}Error: Docker is not running or not accessible${NC}"
+    if ! "$ENGINE" info >/dev/null 2>&1; then
+        echo -e "${RED}Error: $ENGINE is not running or not accessible${NC}"
         exit 1
     fi
 }
@@ -31,7 +35,7 @@ check_docker() {
 # Function to build Docker image
 build_image() {
     echo -e "${YELLOW}Building Docker image...${NC}"
-    docker build -t "$IMAGE_NAME" .
+    "$ENGINE" build -t "$IMAGE_NAME" .
     echo -e "${GREEN}✓ Image built successfully${NC}"
 }
 
@@ -43,7 +47,7 @@ run_docker_test() {
     echo -e "${YELLOW}Running: $test_name${NC}"
     
     # Create container and run test
-    docker run --rm \
+    "$ENGINE" run --rm \
         -v "$(pwd)/$LOG_DIR:/app/$LOG_DIR" \
         -v "$(pwd)/benchmark_results:/app/benchmark_results" \
         --name "$CONTAINER_NAME" \
@@ -60,7 +64,7 @@ run_interactive() {
     echo "Type 'exit' to leave the container."
     echo ""
     
-    docker run -it --rm \
+    "$ENGINE" run -it --rm \
         -v "$(pwd):/app" \
         -w /app \
         --name "$CONTAINER_NAME" \
@@ -71,7 +75,7 @@ run_interactive() {
 # Function to clean up
 cleanup() {
     echo -e "${YELLOW}Cleaning up...${NC}"
-    docker container rm -f "$CONTAINER_NAME" 2>/dev/null || true
+    "$ENGINE" container rm -f "$CONTAINER_NAME" 2>/dev/null || true
 }
 
 # Main script logic


### PR DESCRIPTION
`make docker-build`/`docker-test`/`docker-run` and `scripts/docker_test.sh` hardcoded the `docker` binary, so they failed on podman-only machines. They now auto-detect the container engine (podman preferred, docker fallback), overridable via `CONTAINER_ENGINE=docker`. This mirrors the existing `PYTEST_BIN` auto-detect convention in the Makefile.

This makes the existing devcontainer/Dockerfile reproducibly testable with one command regardless of runtime: `make docker-build && make docker-test`.

Verified under podman: build succeeds and the 30-turn game runs to a clean RESULT line. CI's docker job is unaffected (it invokes `docker` directly, not these targets).