### PR TITLE
Run hosted checks only as pull request gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,9 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   pytest:


### PR DESCRIPTION
## Summary

- Restrict GitHub-hosted automation to pull request merge gates.
- Remove push, schedule, release, and manual-dispatch execution paths in this repository.
- Keep development validation local through repository tests, pre-commit, and act.

## Validation

The native test suite plus pytest and integration jobs passed locally with act.

This PR was opened only after the local gate passed.