### PR TITLE
feat: make strategy agent portfolio ready

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,11 +1,11 @@
 {
-    "name": "AntsAIBot Development",
+    "name": "ants-strategy-agent development",
     "build": {
         "dockerfile": "../Dockerfile",
         "context": ".."
     },
     "runArgs": [
-        "--name=antsaibot-devcontainer"
+        "--name=ants-strategy-agent-devcontainer"
     ],
     "features": {
         "ghcr.io/devcontainers/features/git:1": {},

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,4 @@
-# Docker ignore file for AntsAIBot
+# Docker ignore file for ants-strategy-agent
 # Excludes unnecessary files from Docker build context
 
 # Git

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,9 +77,9 @@ jobs:
         with:
           context: .
           load: true
-          tags: antsaibot:ci
+          tags: ants-strategy-agent:ci
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
       - name: Run make test inside container
-        run: docker run --rm antsaibot:ci make test
+        run: docker run --rm ants-strategy-agent:ci make test

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,13 @@
-# AntsAIBot Testing Makefile
+# ants-strategy-agent testing Makefile
 # Provides easy commands for testing your bot against various opponents
+
+SEED ?= 42
 
 .PHONY: help install install-uv pytest pytest-quick pytest-coverage test test-quick test-full test-against-samples test-against-random test-against-hunter test-against-greedy test-against-lefty test-vs-xathis test-self test-visualize benchmark benchmark-quick benchmark-xathis clean docker-build docker-test docker-run stats stats-json stats-parallel
 
 # Default target
 help:
-	@echo "AntsAIBot Testing Commands:"
+	@echo "ants-strategy-agent testing commands:"
 	@echo ""
 	@echo "Setup:"
 	@echo "  install          Install all Python dependencies (prefers uv, falls back to pip)"
@@ -28,7 +30,7 @@ help:
 	@echo "  test-against-hunter   Test against HunterBot"
 	@echo "  test-against-greedy   Test against GreedyBot"
 	@echo "  test-against-lefty    Test against LeftyBot"
-	@echo "  test-vs-xathis        Test against XathisBot (ported AI Challenge 2011 winner)"
+	@echo "  test-vs-xathis        Test against the partial Xathis reimplementation"
 	@echo ""
 	@echo "Statistical Analysis:"
 	@echo "  stats            Run statistical analysis (default: 10 games, 1000 turns)"
@@ -105,22 +107,22 @@ CONTAINER_ENGINE ?= $(shell command -v podman >/dev/null 2>&1 && echo podman || 
 
 # Build container image
 docker-build:
-	$(CONTAINER_ENGINE) build -t antsaibot .
+	$(CONTAINER_ENGINE) build -t ants-strategy-agent .
 
 # Run tests in a container
 docker-test:
-	$(CONTAINER_ENGINE) run --rm -v $(PWD)/game_logs:/app/game_logs antsaibot make test
+	$(CONTAINER_ENGINE) run --rm -v $(PWD)/game_logs:/app/game_logs ants-strategy-agent make test
 
 # Run interactive container
 docker-run:
-	$(CONTAINER_ENGINE) run -it --rm -v $(PWD):/app -w /app antsaibot /bin/bash
+	$(CONTAINER_ENGINE) run -it --rm -v $(PWD):/app -w /app ants-strategy-agent /bin/bash
 
 # Quick test (30 turns, 2 players)
 test:
 	@echo "Running quick test (30 turns, 2 players)..."
 	PYTHONPATH=. python3 src/tools/playgame.py \
-		--engine_seed 42 \
-		--player_seed 42 \
+		--engine_seed $(SEED) \
+		--player_seed $(SEED) \
 		--end_wait=0.25 \
 		--verbose \
 		--log_dir game_logs \
@@ -259,14 +261,14 @@ test-against-greedy:
 		"python3 src/bots/bot.py" \
 		"python3 src/sample_bots/python/GreedyBot.py"
 
-# Test against XathisBot — the "final boss". This is the Python port of
-# Christoph Pacher's AI Challenge 2011 winner ("xathis"), built into this
-# repo as the ground-truth scripted opponent. If your bot can hold its
-# own here, it's competitive at the world-class level.
+# Test against the partial Python reimplementation of Xathis. The preserved
+# winning Java source is under docs/reference/xathis/; this opponent is not
+# validated as strategically equivalent to it.
 test-vs-xathis:
-	@echo "Testing vs XathisBot (ported AI Challenge 2011 winner)..."
+	@echo "Testing vs the partial Xathis reimplementation..."
 	PYTHONPATH=. python3 src/tools/playgame.py \
-		--player_seed 42 \
+		--engine_seed $(SEED) \
+		--player_seed $(SEED) \
 		--end_wait=0.25 \
 		--verbose \
 		--log_dir game_logs \
@@ -539,20 +541,19 @@ analyze:
 # stable RESULT line emitted by playgame.py.
 benchmark:
 	@echo "Running benchmark suite (5 games / matchup, 1000-turn cap)..."
-	@python3 scripts/benchmark.py
+	@python3 scripts/benchmark.py --seed $(SEED)
 
 # Fast smoke-benchmark — 2 games per matchup, 200-turn cap (~30s total).
 # Useful in CI / sanity checks.
 benchmark-quick:
 	@echo "Running quick benchmark (2 games / matchup, 200-turn cap)..."
-	@python3 scripts/benchmark.py --quick
+	@python3 scripts/benchmark.py --quick --seed $(SEED)
 
-# Run the benchmark suite using XathisBot as the bot under test. Useful
-# for measuring xathis_bot's own absolute strength against the sample
-# bots (and as a regression gate when refactoring its phases).
+# Run the benchmark suite using the partial Xathis reimplementation as the bot
+# under test, providing a regression baseline for its implemented phases.
 benchmark-xathis:
 	@echo "Running benchmark with XathisBot as the bot under test..."
-	@python3 scripts/benchmark.py --bot src/bots/xathis_bot.py
+	@python3 scripts/benchmark.py --bot src/bots/xathis_bot.py --seed $(SEED)
 
 # Validate raw against fast output
 validate:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Ants Strategy Agent
+# ants-strategy-agent
 
 A deterministic multi-agent strategy system for the 2011 Ants AI Challenge,
 packaged with a local game engine, reference opponents, replay visualization,
@@ -17,7 +17,7 @@ the engine/protocol boundary covered by tests.
 | Evaluation | [`Makefile`](Makefile), [`scripts/benchmark.py`](scripts/benchmark.py) | Named head-to-head, probabilistic, and benchmark entry points |
 | Regression protection | [`tests/`](tests), [PR workflow](.github/workflows/ci.yml) | Unit, protocol, engine, sample-bot, Docker, and real-game checks |
 | Qualitative debugging | [`visualizer/`](visualizer) | Browser replay inspection for behavior and failure analysis |
-| Strong reference opponent | [`src/bots/xathis_bot.py`](src/bots/xathis_bot.py), [`docs/reference/xathis/`](docs/reference/xathis) | Tested Python port anchored to preserved historical source |
+| Historical comparison | [`src/bots/xathis_bot.py`](src/bots/xathis_bot.py), [`docs/reference/xathis/`](docs/reference/xathis) | Partial Python reimplementation beside the preserved winning Java source |
 
 ## System design
 
@@ -59,6 +59,17 @@ make test
 make test-vs-xathis
 make benchmark-xathis
 ```
+
+Reproducing an engine run requires two independent values. `engine_seed`
+controls engine-side randomness such as food generation; `player_seed` is sent
+to each bot so opponents with randomized policies can reproduce their choices.
+The showcased Make targets default to `SEED=42`: game targets pass it as both
+values, while the benchmark runner uses it as a recorded master seed from which
+it derives and records an engine/player seed pair for every game. Override it
+with a command such as `make benchmark SEED=73`. The same code revision, map,
+arguments, bot revisions, and both per-game seeds are required for a repeatable
+comparison. Wall-clock timeouts and runtime differences remain external
+sources of variation.
 
 [`statistics.json`](statistics.json) and
 [`parallel_statistics.json`](parallel_statistics.json) are retained historical
@@ -107,7 +118,7 @@ same checks locally before opening or updating a PR.
 ```
 src/
 ├── ants/               # engine, game state, protocol, sandbox
-├── bots/               # strategy bot and Xathis reference port
+├── bots/               # strategy bot and partial Xathis reimplementation
 ├── sample_bots/        # fixed evaluation opponents in several languages
 └── tools/              # match runner and map generation
 tests/                  # deterministic regression suite
@@ -119,14 +130,23 @@ docs/reference/xathis/  # preserved historical reference source
 
 ## Scope and provenance
 
-Taylor's work is the strategy implementation, Python reference port,
-integration hardening, tests, benchmark/analysis tooling, and developer
-workflow around the challenge. The repository also preserves challenge-engine,
-sample-opponent, visualizer, and historical Xathis reference material so the
-system can be exercised locally. Those retained components are reference and
-compatibility inputs, not presented as original work; see
+Taylor's work includes the strategy implementation, partial Python Xathis
+reimplementation, integration hardening, tests, benchmark/analysis tooling,
+and developer workflow around the challenge. The repository also preserves
+challenge-engine, sample-opponent, visualizer, and historical Xathis reference
+material so the system can be exercised locally. Those retained components are
+reference and compatibility inputs, not presented as original work; see
 [`docs/gitroll-triage.md`](docs/gitroll-triage.md) for the explicit maintenance
 boundary.
+
+The preserved Java sources under `docs/reference/xathis/` are the historical
+first-place Xathis bot. `src/bots/xathis_bot.py` is an incomplete Python
+reimplementation: several strategy phases remain no-ops, and its combat search
+is a simplified, bounded substitute for the original algorithm. Its tests show
+that the implemented pieces and engine integration work; they do not establish
+strategic fidelity or strength equivalent to the winning Java bot. Xathis
+matchups in this repository are therefore regression and comparison inputs,
+not evidence of world-class competitive performance.
 
 The repository does not currently publish a repository-wide license file.
 Third-party source remains subject to its original terms and retained notices.

--- a/README.md
+++ b/README.md
@@ -1,227 +1,132 @@
-# Ants AI Bot: Multi-Agent Strategy Implementation
+# Ants Strategy Agent
 
-**A competitive AI bot for the Ants AI Challenge implementing hierarchical decision-making and strategic optimization**
+A deterministic multi-agent strategy system for the 2011 Ants AI Challenge,
+packaged with a local game engine, reference opponents, replay visualization,
+benchmark tooling, and PR-gated tests.
 
-I built this bot to compete in the Ants AI Challenge, focusing on creating an intelligent agent that can make strategic decisions in real-time while managing multiple competing objectives. The challenge requires balancing food collection, colony expansion, territory control, and enemy engagement - essentially a multi-objective optimization problem with dynamic constraints.
+The engineering focus is the evaluation loop around the bot: run repeatable
+matches, inspect replays, compare strategies against fixed opponents, and keep
+the engine/protocol boundary covered by tests.
 
-## What I Built
+## At a glance
 
-### Core Decision System
-I implemented a hierarchical priority system that balances competing objectives:
-- **Colony multiplication** (highest priority) - ensuring ants return to hills for reproduction
-- **Strategic combat** - targeting enemy hills and ants when advantageous  
-- **Resource acquisition** - aggressive food collection with dynamic distance thresholds
-- **Exploration** - systematic map discovery using wall-following algorithms
+| Area | Public evidence | Signal |
+| --- | --- | --- |
+| Strategy implementation | [`src/bots/bot.py`](src/bots/bot.py) | Hierarchical objectives, persistent orders, collision avoidance, exploration, and combat heuristics |
+| Game runtime | [`src/ants/`](src/ants), [`src/tools/playgame.py`](src/tools/playgame.py) | Local engine, sandboxing, protocol parsing, and match orchestration |
+| Evaluation | [`Makefile`](Makefile), [`scripts/benchmark.py`](scripts/benchmark.py) | Named head-to-head, probabilistic, and benchmark entry points |
+| Regression protection | [`tests/`](tests), [PR workflow](.github/workflows/ci.yml) | Unit, protocol, engine, sample-bot, Docker, and real-game checks |
+| Qualitative debugging | [`visualizer/`](visualizer) | Browser replay inspection for behavior and failure analysis |
+| Strong reference opponent | [`src/bots/xathis_bot.py`](src/bots/xathis_bot.py), [`docs/reference/xathis/`](docs/reference/xathis) | Tested Python port anchored to preserved historical source |
 
-### Key Algorithms
-**Multi-Objective Optimization**: The bot uses a priority-based decision tree where each ant evaluates multiple objectives and selects the highest-priority action available. This prevents getting stuck in local optima (like collecting all food without reproducing).
+## System design
 
-**Dynamic Thresholding**: Food hunting distances adapt based on colony size - when I have fewer ants, the bot hunts food from much further away (up to 50 tiles) to catch up to opponents.
-
-**Pathfinding & Navigation**: Uses breadth-first search for optimal pathfinding and implements wall-following exploration patterns adapted from computational geometry principles.
-
-**State Management**: Tracks game state efficiently using dictionaries and sets, with a standing orders system that persists tasks across multiple turns.
-
-### Technical Implementation
-The bot combines insights from studying successful opponents (LeftyBot's exploration, GreedyBot's priority system) with my own optimizations:
-
-- **Aggressive multiplication strategy** - returns to hills when ant count ≤ 20
-- **Strategic combat** - only hunts enemy ants when I have numerical advantage
-- **Enhanced exploration** - multiple exploration patterns beyond simple wall-following
-- **Efficient collision avoidance** - prevents multiple ants from targeting the same destination
-
-## Current Status & Performance
-
-The bot is functional but still underperforming against advanced opponents. Here's what I've learned:
-
-### What Works
-- **Hill return mechanics** - Fixed a critical bug where ants collected food but didn't return to hills for multiplication
-- **Aggressive food hunting** - Extended hunting distances to 50+ tiles when colony is small
-- **Strategic combat** - Only engages enemies when I have numerical advantage
-- **Exploration patterns** - Multiple exploration strategies beyond basic wall-following
-
-### Current Challenges
-- **Performance against LeftyBot** - Still losing to systematic wall-following exploration
-- **Food collection efficiency** - GreedyBot's direct food collection strategy outperforms my approach
-- **Multi-objective balance** - Need better tuning of priority weights and thresholds
-
-### Performance Metrics
-| Opponent | Result | Key Issue |
-|----------|--------|-----------|
-| RandomBot | Win (deterministic baseline) | RandomBot dies / hangs out — bot reliably wins |
-| GreedyBot | Loss (16 vs 31 ants) | Food collection strategy needs work |
-| HunterBot | Loss (6 vs 4 ants) | Combat mechanics need refinement |
-| LeftyBot | Loss (11 vs 52 ants) | Exploration strategy needs improvement |
-| **XathisBot** | **Loss (final boss)** | Port of the AI Challenge 2011 winner — see below |
-
-### The "Final Boss": XathisBot
-
-`src/bots/xathis_bot.py` is a Python port of the **AI Challenge 2011 winner**
-("xathis", written in Java). The original source and the recovered postmortem
-live at `docs/reference/xathis/`. xathis uses the same general phases as a
-strong scripted bot (food BFS, exploration, hill attack, defence) but adds
-two things that pushed it past every other entry in the world:
-
-1. **Diffusion-based exploration** — every tile accumulates a "fog" value over
-   time; ants are pulled toward the highest-value frontier (`_init_explore`
-   + `_explore`).
-2. **Group-based combat with minimax** — ants in mutual gamma-distance form a
-   "fight group"; we exhaustively search every (my_combo × enemy_combo) and
-   pick the move that maximises `(enemy_dead − my_dead)` under the official
-   battle-resolution rule (`_fight`).
-
-Empirical (3 games × 500 turns on `random_walk_02p_01`):
-
-| Opponent | XathisBot wins | XathisBot losses | Draws |
-|----------|---:|---:|---:|
-| RandomBot | 3 | 0 | 0 |
-| HoldBot   | 3 | 0 | 0 |
-| HunterBot | 3 | 0 | 0 |
-| GreedyBot | 3 | 0 | 0 |
-| LeftyBot  | 3 | 0 | 0 |
-| 4-Player  | 3 | 0 | 0 |
-
-That's the bar: any successor (the ML/RL bot you're planning) must beat
-xathis_bot to be world-class. Try it yourself:
-
-```bash
-make test-vs-xathis      # one head-to-head game with replay
-make benchmark-xathis    # full benchmark suite, xathis under test
+```text
+map + game state
+       │
+       ▼
+priority policy
+  1. continue valid standing orders
+  2. protect colony growth
+  3. target enemy hills
+  4. collect food
+  5. engage when advantageous
+  6. explore unseen space
+       │
+       ▼
+collision-safe orders ──► engine / sandbox ──► replay + result artifacts
+                                      │
+                                      └──────► benchmark aggregation
 ```
 
-## Testing & Evaluation
+This is a rule-based game agent, not a trained language model or reinforcement-
+learning policy. The repository does include a reward-design analysis for a
+possible learned successor, but that document is a design exercise rather than
+implemented RL behavior.
 
-I built a comprehensive testing framework to systematically evaluate performance:
+## Evaluation contract
 
-### Testing Infrastructure
-- **Probabilistic testing** - Run 10+ games per opponent to calculate win rates
-- **Performance benchmarking** - Track ant efficiency, territory control, resource utilization
-- **Game replay analysis** - Visualize bot behavior and identify improvement areas
-- **Automated test suite** - Makefile commands for consistent testing
+The project supports three useful levels of evidence:
 
-### Reward Function Analysis
-I documented the implicit reward structure in `reward_analysis.md` and designed a framework for potential reinforcement learning:
-
-```python
-def calculate_reward(state, action, next_state):
-    reward = 0.0
-    
-    # Primary objectives
-    ant_count_reward = (next_state.my_ants - state.my_ants) * 10.0
-    food_collected_reward = (state.food_collected - next_state.food_collected) * 5.0
-    enemy_ants_killed_reward = (state.enemy_ants - next_state.enemy_ants) * 15.0
-    
-    # Penalties
-    ant_death_penalty = (state.my_ants - next_state.my_ants) * -5.0
-    starvation_penalty = -1.0 if next_state.my_ants == 0 else 0.0
-    
-    return reward
-```
-
-## Next Steps
-
-### Immediate Improvements
-1. **Better exploration strategy** - Study LeftyBot's wall-following more carefully
-2. **Food collection optimization** - Analyze GreedyBot's efficiency techniques  
-3. **Combat mechanics** - Improve enemy ant hunting and hill targeting
-4. **Threshold tuning** - Optimize distance thresholds and priority weights
-
-### Future Development
-1. **Reinforcement Learning** - Implement the reward function framework I designed
-2. **Neural Networks** - Use the state space architecture for deep learning
-3. **Self-play training** - Multi-agent learning with multiple bot instances
-4. **Transfer learning** - Adapt strategies across different map configurations
-
-## Getting Started
-
-### Setup
-The project uses [`uv`](https://docs.astral.sh/uv/) as the canonical
-package manager (with `pip` as a fallback). Dependencies are declared in
-`pyproject.toml`; lock state lives in `uv.lock`.
+1. `make pytest` checks deterministic components and structural contracts.
+2. `make test` runs a real 30-turn game through the local engine.
+3. Benchmark targets run repeated matches against named reference opponents and
+   emit machine-readable results for analysis.
 
 ```bash
-git clone <repository-url>
-cd AntsAIBot
-
-# One-step install (uses uv if available, falls back to pip + venv).
-make install
-
-# Or, manually:
-uv sync --all-extras                      # canonical
-# pip install -e ".[dev]"                 # fallback
-
-make test                # Run a quick 30-turn integration game
-make pytest              # Run the unit-test suite (~140 tests)
-make visualize-latest    # Open the latest replay in your browser
+make pytest
+make test
+make test-vs-xathis
+make benchmark-xathis
 ```
 
-The project ships three optional dependency extras:
+[`statistics.json`](statistics.json) and
+[`parallel_statistics.json`](parallel_statistics.json) are retained historical
+runs, not a current leaderboard. They were produced at different times and do
+not establish a general win-rate claim. A publishable comparison should record
+the code revision, map set, seeds, turn limit, opponent revision, raw results,
+and aggregation command in the same evidence bundle.
 
-| Extra | What it adds | When you need it |
-|-------|--------------|------------------|
-| `[test]` | `pytest`, `pytest-cov` | Running the unit-test suite |
-| `[analysis]` | `pandas`, `numpy`, `matplotlib`, `seaborn`, `scipy` | Running `scripts/analyze_results.py` and statistical analysis Make targets |
-| `[dev]` | Both of the above | Local development |
+## Local setup
 
-### Testing
+The canonical environment uses [`uv`](https://docs.astral.sh/uv/):
+
 ```bash
-# Unit tests (fast — uses pytest)
-make pytest                 # Full suite
-make pytest-quick           # Skip subprocess sample-bot tests
-make pytest-coverage        # With coverage report
+git clone https://github.com/T-Py-T/ants-strategy-agent.git
+cd ants-strategy-agent
+uv sync --all-extras
 
-# Integration testing (real games)
-make test-probabilistic     # Statistical analysis (10 games per opponent)
-make test-against-samples   # Multi-opponent testing
-make benchmark              # Performance benchmarking
-
-# Test against specific opponents
-make test-against-random    # Baseline
-make test-against-greedy    # Food collection
-make test-against-hunter    # Combat
+make pytest
+make test
+make visualize-latest
 ```
 
-### Development
+Optional dependency groups are explicit so a contributor can install only the
+surface being exercised:
+
+| Extra | Contents | Use |
+| --- | --- | --- |
+| `[test]` | pytest and coverage support | Unit and integration regression checks |
+| `[analysis]` | pandas, NumPy, SciPy, Matplotlib, and Seaborn | Benchmark aggregation and plots |
+| `[dev]` | Both groups | Complete contributor environment |
+
+Docker and a VS Code dev container are available when a host-local Python/Java
+toolchain is undesirable:
+
 ```bash
-# Docker environment
 make docker-build
 make docker-test
-
-# VS Code Dev Container
-# Open in VS Code → "Dev Containers: Reopen in Container"
-# (auto-runs `uv sync --all-extras` on first start)
 ```
 
-### Continuous Integration
-Every push and pull request runs the full pytest matrix on Python 3.12 /
-3.13, plus a real-game integration check (`make test`) and a
-Docker image build/run smoke test, via `.github/workflows/ci.yml`.
+The hosted workflow is intentionally a pull-request merge gate. Routine branch
+pushes do not consume GitHub Actions minutes; agents are expected to run the
+same checks locally before opening or updating a PR.
 
 ## Project Structure
 
 ```
-AntsAIBot/
-├── .devcontainer/       # VS Code Dev Container configuration
-├── .github/workflows/   # GitHub Actions CI (pytest matrix + integration + docker)
-├── src/
-│   ├── ants/            # Game engine (Ants, Game, sandbox, run_game)
-│   ├── bots/            # AdvancedBot — my bot implementation
-│   ├── sample_bots/     # Reference opponents (Python / Java / C# / PHP)
-│   └── tools/
-│       ├── playgame.py  # Engine driver / runner
-│       └── mapgen/      # Map-generation utilities
-├── tests/               # pytest suite (unit + structural backstops)
-├── visualizer/          # Game replay visualization
-├── scripts/             # Statistical-analysis + benchmarking scripts
-├── maps/                # Game maps (example, maze, multi_hill_maze, random_walk)
-├── submission_test/     # Submission packaging sandbox
-├── game_logs/           # Test outputs and game replays
-├── pyproject.toml       # Project metadata, deps, extras, pytest config
-├── uv.lock              # Pinned dependency resolution
-├── Dockerfile           # Slim runtime image (Python 3.13 + JDK 21)
-└── Makefile             # Friendly entry points for every workflow
+src/
+├── ants/               # engine, game state, protocol, sandbox
+├── bots/               # strategy bot and Xathis reference port
+├── sample_bots/        # fixed evaluation opponents in several languages
+└── tools/              # match runner and map generation
+tests/                  # deterministic regression suite
+scripts/                # benchmark and analysis entry points
+visualizer/             # replay viewer
+maps/                   # retained evaluation maps
+docs/reference/xathis/  # preserved historical reference source
 ```
 
----
+## Scope and provenance
 
-For more details on the Ants AI Challenge, see the [official tutorial](http://ants.aichallenge.org/ants_tutorial.php).
+Taylor's work is the strategy implementation, Python reference port,
+integration hardening, tests, benchmark/analysis tooling, and developer
+workflow around the challenge. The repository also preserves challenge-engine,
+sample-opponent, visualizer, and historical Xathis reference material so the
+system can be exercised locally. Those retained components are reference and
+compatibility inputs, not presented as original work; see
+[`docs/gitroll-triage.md`](docs/gitroll-triage.md) for the explicit maintenance
+boundary.
+
+The repository does not currently publish a repository-wide license file.
+Third-party source remains subject to its original terms and retained notices.

--- a/docs/gitroll-triage.md
+++ b/docs/gitroll-triage.md
@@ -39,69 +39,69 @@ findings are counted once across those two issue bodies.
 
 | Issue | File | Findings | Disposition |
 | --- | --- | ---: | --- |
-| [#7](https://github.com/T-Py-T/AntsAIBot/issues/7) | `docs/reference/xathis/Strategy.java` (1/2) | 169 | Reference snapshot; preserved as ground truth for the Python port. |
-| [#8](https://github.com/T-Py-T/AntsAIBot/issues/8) | `docs/reference/xathis/Strategy.java` (2/2) | 33 | Reference snapshot; preserved as ground truth for the Python port. |
-| [#9](https://github.com/T-Py-T/AntsAIBot/issues/9) | `src/ants/ants.py` | 54 | Fixed 40 safe findings, including the identical attack branch and always-true comparison. Deferred 14 game-engine complexity rewrites pending golden replay equivalence. |
-| [#10](https://github.com/T-Py-T/AntsAIBot/issues/10) | `src/sample_bots/java/Tile.java` | 2 | Fixed null-unsafe equality and made the override explicit. Kept the default package so the sample bot sources continue to compile and launch directly from their directory. |
-| [#11](https://github.com/T-Py-T/AntsAIBot/issues/11) | `src/tools/mapgen/MapGenerator.java` | 24 | Fixed 21 findings: all three null paths plus 18 safe validation, naming, modifier, append, and array-copy smells. The start-position loop remains unchanged pending deterministic map equivalence; `System.out` is the API's requested map output, and the default package preserves direct sibling compilation. |
-| [#12](https://github.com/T-Py-T/AntsAIBot/issues/12) | `src/tools/mapgen/McMaps.py` | 55 | Fixed 39 findings, including the Python 3 sort failure, shadowed builtins, no-op/debug blocks, unused locals and indices, type checks, and stale commented code. Deferred 16 behavior-sensitive or incomplete items: seven complexity rewrites, five TODO implementations, the unfinished Delaunay merge, and three unused settings in the unfinished `cell_maze` prototype. |
-| [#13](https://github.com/T-Py-T/AntsAIBot/issues/13) | `src/tools/mapgen/SymmetricMapgen.java` | 25 | Fixed 23 findings: integer overflow plus unused fields, modifier order, redundant casts, boolean flow, and stack modernization. `System.out` is the standalone generator's CLI output, and the default package preserves direct launch. |
-| [#14](https://github.com/T-Py-T/AntsAIBot/issues/14) | `visualizer/copy_paste.html` | 1 | Fixed the missing document language. |
-| [#15](https://github.com/T-Py-T/AntsAIBot/issues/15) | `visualizer/js/CanvasElement.js` | 81 | Bundled upstream visualizer; preserved under the global-script compatibility policy above. |
-| [#16](https://github.com/T-Py-T/AntsAIBot/issues/16) | `docs/reference/xathis/Ant.java` | 36 | Reference snapshot; preserved. |
-| [#17](https://github.com/T-Py-T/AntsAIBot/issues/17) | `docs/reference/xathis/Connection.java` | 39 | Reference snapshot; preserved. |
-| [#18](https://github.com/T-Py-T/AntsAIBot/issues/18) | `docs/reference/xathis/Direction.java` | 4 | Reference snapshot; preserved. |
-| [#19](https://github.com/T-Py-T/AntsAIBot/issues/19) | `docs/reference/xathis/Logger.java` | 25 | Reference snapshot; preserved. |
-| [#20](https://github.com/T-Py-T/AntsAIBot/issues/20) | `docs/reference/xathis/MyBot.java` | 1 | Reference snapshot; preserved. |
-| [#21](https://github.com/T-Py-T/AntsAIBot/issues/21) | `docs/reference/xathis/Tile.java` | 28 | Reference snapshot; preserved. |
-| [#22](https://github.com/T-Py-T/AntsAIBot/issues/22) | `docs/reference/xathis/Type.java` | 3 | Reference snapshot; preserved. |
-| [#23](https://github.com/T-Py-T/AntsAIBot/issues/23) | `scripts/analyze_results.py` | 9 | Fixed all findings; split loading/normalization helpers, removed confusing strings/conditional, and removed the constant condition. |
-| [#24](https://github.com/T-Py-T/AntsAIBot/issues/24) | `src/ants/engine.py` | 19 | Fixed 17 safe findings and centralized protocol-line literals. Deferred the two main loop complexity rewrites pending golden full-game equivalence. |
-| [#25](https://github.com/T-Py-T/AntsAIBot/issues/25) | `src/ants/sandbox.py` | 5 | Fixed all findings. |
-| [#26](https://github.com/T-Py-T/AntsAIBot/issues/26) | `src/bots/ants.py` | 6 | Fixed three safe findings. Deferred three protocol-parser/direction complexity rewrites to preserve the bot wire contract. |
-| [#27](https://github.com/T-Py-T/AntsAIBot/issues/27) | `src/bots/bot.py` | 11 | Fixed nine safe findings, including explicit imports and idiomatic membership checks. Deferred two strategy complexity rewrites pending game-outcome equivalence. |
-| [#28](https://github.com/T-Py-T/AntsAIBot/issues/28) | `src/bots/xathis_bot.py` | 17 | Fixed four safe findings and updated direct tests for the narrowed battle helper. Deferred 13 complexity rewrites because this port is the benchmark oracle for the historical winner. |
-| [#29](https://github.com/T-Py-T/AntsAIBot/issues/29) | `src/sample_bots/java/Aim.java` | 5 | Multi-language reference opponent; preserved. |
-| [#30](https://github.com/T-Py-T/AntsAIBot/issues/30) | `src/sample_bots/java/Ants.java` | 24 | Multi-language protocol/reference fixture; preserved. |
-| [#31](https://github.com/T-Py-T/AntsAIBot/issues/31) | `src/sample_bots/java/Bot.java` | 2 | Multi-language protocol/reference fixture; preserved. |
-| [#32](https://github.com/T-Py-T/AntsAIBot/issues/32) | `src/sample_bots/java/HunterBot.java` | 4 | Reference opponent; preserved. |
-| [#33](https://github.com/T-Py-T/AntsAIBot/issues/33) | `src/sample_bots/java/Ilk.java` | 3 | Multi-language protocol/reference fixture; preserved. |
-| [#34](https://github.com/T-Py-T/AntsAIBot/issues/34) | `src/sample_bots/java/LeftyBot.java` | 10 | Reference opponent; preserved. |
-| [#35](https://github.com/T-Py-T/AntsAIBot/issues/35) | `src/sample_bots/java/RandomBot.java` | 3 | Reference opponent; preserved. |
-| [#36](https://github.com/T-Py-T/AntsAIBot/issues/36) | `src/sample_bots/php/Ants.php` | 9 | Multi-language protocol/reference fixture; preserved. |
-| [#37](https://github.com/T-Py-T/AntsAIBot/issues/37) | `src/sample_bots/php/HunterBot.php` | 3 | Reference opponent; preserved. |
-| [#38](https://github.com/T-Py-T/AntsAIBot/issues/38) | `src/sample_bots/php/LeftyBot.php` | 3 | Reference opponent; preserved. |
-| [#39](https://github.com/T-Py-T/AntsAIBot/issues/39) | `src/sample_bots/php/MyBot.php` | 2 | Reference opponent; preserved. |
-| [#40](https://github.com/T-Py-T/AntsAIBot/issues/40) | `src/sample_bots/php/RandomBot.php` | 2 | Reference opponent; preserved. |
-| [#41](https://github.com/T-Py-T/AntsAIBot/issues/41) | `src/sample_bots/python/ants.py` | 6 | Protocol/reference fixture shared by sample opponents; preserved. |
-| [#42](https://github.com/T-Py-T/AntsAIBot/issues/42) | `src/sample_bots/python/ErrorBot.py` | 3 | Deliberately failing engine-error fixture; preserved. |
-| [#43](https://github.com/T-Py-T/AntsAIBot/issues/43) | `src/sample_bots/python/GreedyBot.py` | 5 | Reference opponent; preserved. |
-| [#44](https://github.com/T-Py-T/AntsAIBot/issues/44) | `src/sample_bots/python/HoldBot.py` | 2 | Reference opponent; preserved. |
-| [#45](https://github.com/T-Py-T/AntsAIBot/issues/45) | `src/sample_bots/python/HunterBot.py` | 2 | Reference opponent; preserved. |
-| [#46](https://github.com/T-Py-T/AntsAIBot/issues/46) | `src/sample_bots/python/InvalidBot.py` | 1 | Deliberately invalid engine-protocol fixture; preserved. |
-| [#47](https://github.com/T-Py-T/AntsAIBot/issues/47) | `src/sample_bots/python/LeftyBot.py` | 6 | Reference opponent; preserved. |
-| [#48](https://github.com/T-Py-T/AntsAIBot/issues/48) | `src/sample_bots/python/logutils.py` | 2 | Support code for sample/reference opponents; preserved. |
-| [#49](https://github.com/T-Py-T/AntsAIBot/issues/49) | `src/sample_bots/python/RandomBot.py` | 2 | Reference opponent; preserved. |
-| [#50](https://github.com/T-Py-T/AntsAIBot/issues/50) | `src/sample_bots/python/TimeoutBot.py` | 1 | Deliberately timing-out engine fixture; preserved. |
-| [#51](https://github.com/T-Py-T/AntsAIBot/issues/51) | `src/tools/mapgen/asymmetric_mapgen.py` | 14 | Fixed all findings. |
-| [#52](https://github.com/T-Py-T/AntsAIBot/issues/52) | `src/tools/mapgen/heightmap.py` | 5 | Fixed three safe findings. Deferred two seed-sensitive algorithm complexity rewrites pending golden map fixtures. |
-| [#53](https://github.com/T-Py-T/AntsAIBot/issues/53) | `src/tools/mapgen/map.py` | 18 | Fixed 15 safe findings, including exception specificity and the swallowed indexing error. Deferred two complexity rewrites and the public `map` field rename because all generators depend on that interface. |
-| [#54](https://github.com/T-Py-T/AntsAIBot/issues/54) | `src/tools/mapgen/mapgen.py` | 34 | Fixed all 28 mechanical findings. Deferred six seed-sensitive algorithm/CLI complexity rewrites pending golden map fixtures. |
-| [#55](https://github.com/T-Py-T/AntsAIBot/issues/55) | `src/tools/mapgen/MapWalker.java` | 9 | Fixed eight safe modifier, cast, stack, and boolean-flow findings. Kept the default package because relocation would break direct compilation with sibling generators. |
-| [#56](https://github.com/T-Py-T/AntsAIBot/issues/56) | `src/tools/mapgen/random_map.py` | 1 | Fixed the wildcard import. |
-| [#57](https://github.com/T-Py-T/AntsAIBot/issues/57) | `src/tools/mapgen/symmetric_mapgen.py` | 8 | Fixed seven mechanical findings. Deferred one seed-sensitive algorithm complexity rewrite pending golden map fixtures. |
-| [#58](https://github.com/T-Py-T/AntsAIBot/issues/58) | `src/tools/mapgen/Test.java` | 3 | Removed the stale commented-out call. `System.out` is the manual harness output, and the default package preserves direct sibling compilation. |
-| [#59](https://github.com/T-Py-T/AntsAIBot/issues/59) | `src/tools/playgame.py` | 3 | Fixed the broad import catch and duplicate log-name literal. Deferred the monolithic CLI orchestration rewrite pending golden end-to-end games. |
-| [#60](https://github.com/T-Py-T/AntsAIBot/issues/60) | `visualizer/js/Ant.js` | 10 | Bundled upstream visualizer; preserved under the compatibility policy above. |
-| [#61](https://github.com/T-Py-T/AntsAIBot/issues/61) | `visualizer/js/Application.js` | 133 | Bundled upstream visualizer; preserved under the compatibility policy above. |
-| [#62](https://github.com/T-Py-T/AntsAIBot/issues/62) | `visualizer/js/Buttons.js` | 34 | Bundled upstream visualizer; preserved under the compatibility policy above. |
-| [#63](https://github.com/T-Py-T/AntsAIBot/issues/63) | `visualizer/js/Config.js` | 11 | Bundled upstream visualizer; preserved under the compatibility policy above. |
-| [#64](https://github.com/T-Py-T/AntsAIBot/issues/64) | `visualizer/js/Const.js` | 16 | Bundled upstream visualizer; preserved under the compatibility policy above. |
-| [#65](https://github.com/T-Py-T/AntsAIBot/issues/65) | `visualizer/js/Director.js` | 14 | Bundled upstream visualizer; preserved under the compatibility policy above. |
-| [#66](https://github.com/T-Py-T/AntsAIBot/issues/66) | `visualizer/js/ImageManager.js` | 12 | Bundled upstream visualizer; preserved under the compatibility policy above. |
-| [#67](https://github.com/T-Py-T/AntsAIBot/issues/67) | `visualizer/js/Replay.js` | 97 | Bundled upstream visualizer; preserved under the compatibility policy above. |
-| [#68](https://github.com/T-Py-T/AntsAIBot/issues/68) | `visualizer/js/Util.js` | 36 | Bundled upstream visualizer; preserved under the compatibility policy above. |
-| [#69](https://github.com/T-Py-T/AntsAIBot/issues/69) | `visualizer/js/visualizer.js` | 11 | Bundled upstream visualizer; preserved under the compatibility policy above. |
+| [#7](https://github.com/T-Py-T/ants-strategy-agent/issues/7) | `docs/reference/xathis/Strategy.java` (1/2) | 169 | Reference snapshot; preserved as ground truth for the Python port. |
+| [#8](https://github.com/T-Py-T/ants-strategy-agent/issues/8) | `docs/reference/xathis/Strategy.java` (2/2) | 33 | Reference snapshot; preserved as ground truth for the Python port. |
+| [#9](https://github.com/T-Py-T/ants-strategy-agent/issues/9) | `src/ants/ants.py` | 54 | Fixed 40 safe findings, including the identical attack branch and always-true comparison. Deferred 14 game-engine complexity rewrites pending golden replay equivalence. |
+| [#10](https://github.com/T-Py-T/ants-strategy-agent/issues/10) | `src/sample_bots/java/Tile.java` | 2 | Fixed null-unsafe equality and made the override explicit. Kept the default package so the sample bot sources continue to compile and launch directly from their directory. |
+| [#11](https://github.com/T-Py-T/ants-strategy-agent/issues/11) | `src/tools/mapgen/MapGenerator.java` | 24 | Fixed 21 findings: all three null paths plus 18 safe validation, naming, modifier, append, and array-copy smells. The start-position loop remains unchanged pending deterministic map equivalence; `System.out` is the API's requested map output, and the default package preserves direct sibling compilation. |
+| [#12](https://github.com/T-Py-T/ants-strategy-agent/issues/12) | `src/tools/mapgen/McMaps.py` | 55 | Fixed 39 findings, including the Python 3 sort failure, shadowed builtins, no-op/debug blocks, unused locals and indices, type checks, and stale commented code. Deferred 16 behavior-sensitive or incomplete items: seven complexity rewrites, five TODO implementations, the unfinished Delaunay merge, and three unused settings in the unfinished `cell_maze` prototype. |
+| [#13](https://github.com/T-Py-T/ants-strategy-agent/issues/13) | `src/tools/mapgen/SymmetricMapgen.java` | 25 | Fixed 23 findings: integer overflow plus unused fields, modifier order, redundant casts, boolean flow, and stack modernization. `System.out` is the standalone generator's CLI output, and the default package preserves direct launch. |
+| [#14](https://github.com/T-Py-T/ants-strategy-agent/issues/14) | `visualizer/copy_paste.html` | 1 | Fixed the missing document language. |
+| [#15](https://github.com/T-Py-T/ants-strategy-agent/issues/15) | `visualizer/js/CanvasElement.js` | 81 | Bundled upstream visualizer; preserved under the global-script compatibility policy above. |
+| [#16](https://github.com/T-Py-T/ants-strategy-agent/issues/16) | `docs/reference/xathis/Ant.java` | 36 | Reference snapshot; preserved. |
+| [#17](https://github.com/T-Py-T/ants-strategy-agent/issues/17) | `docs/reference/xathis/Connection.java` | 39 | Reference snapshot; preserved. |
+| [#18](https://github.com/T-Py-T/ants-strategy-agent/issues/18) | `docs/reference/xathis/Direction.java` | 4 | Reference snapshot; preserved. |
+| [#19](https://github.com/T-Py-T/ants-strategy-agent/issues/19) | `docs/reference/xathis/Logger.java` | 25 | Reference snapshot; preserved. |
+| [#20](https://github.com/T-Py-T/ants-strategy-agent/issues/20) | `docs/reference/xathis/MyBot.java` | 1 | Reference snapshot; preserved. |
+| [#21](https://github.com/T-Py-T/ants-strategy-agent/issues/21) | `docs/reference/xathis/Tile.java` | 28 | Reference snapshot; preserved. |
+| [#22](https://github.com/T-Py-T/ants-strategy-agent/issues/22) | `docs/reference/xathis/Type.java` | 3 | Reference snapshot; preserved. |
+| [#23](https://github.com/T-Py-T/ants-strategy-agent/issues/23) | `scripts/analyze_results.py` | 9 | Fixed all findings; split loading/normalization helpers, removed confusing strings/conditional, and removed the constant condition. |
+| [#24](https://github.com/T-Py-T/ants-strategy-agent/issues/24) | `src/ants/engine.py` | 19 | Fixed 17 safe findings and centralized protocol-line literals. Deferred the two main loop complexity rewrites pending golden full-game equivalence. |
+| [#25](https://github.com/T-Py-T/ants-strategy-agent/issues/25) | `src/ants/sandbox.py` | 5 | Fixed all findings. |
+| [#26](https://github.com/T-Py-T/ants-strategy-agent/issues/26) | `src/bots/ants.py` | 6 | Fixed three safe findings. Deferred three protocol-parser/direction complexity rewrites to preserve the bot wire contract. |
+| [#27](https://github.com/T-Py-T/ants-strategy-agent/issues/27) | `src/bots/bot.py` | 11 | Fixed nine safe findings, including explicit imports and idiomatic membership checks. Deferred two strategy complexity rewrites pending game-outcome equivalence. |
+| [#28](https://github.com/T-Py-T/ants-strategy-agent/issues/28) | `src/bots/xathis_bot.py` | 17 | Fixed four safe findings and updated direct tests for the narrowed battle helper. Deferred 13 complexity rewrites because this port is the benchmark oracle for the historical winner. |
+| [#29](https://github.com/T-Py-T/ants-strategy-agent/issues/29) | `src/sample_bots/java/Aim.java` | 5 | Multi-language reference opponent; preserved. |
+| [#30](https://github.com/T-Py-T/ants-strategy-agent/issues/30) | `src/sample_bots/java/Ants.java` | 24 | Multi-language protocol/reference fixture; preserved. |
+| [#31](https://github.com/T-Py-T/ants-strategy-agent/issues/31) | `src/sample_bots/java/Bot.java` | 2 | Multi-language protocol/reference fixture; preserved. |
+| [#32](https://github.com/T-Py-T/ants-strategy-agent/issues/32) | `src/sample_bots/java/HunterBot.java` | 4 | Reference opponent; preserved. |
+| [#33](https://github.com/T-Py-T/ants-strategy-agent/issues/33) | `src/sample_bots/java/Ilk.java` | 3 | Multi-language protocol/reference fixture; preserved. |
+| [#34](https://github.com/T-Py-T/ants-strategy-agent/issues/34) | `src/sample_bots/java/LeftyBot.java` | 10 | Reference opponent; preserved. |
+| [#35](https://github.com/T-Py-T/ants-strategy-agent/issues/35) | `src/sample_bots/java/RandomBot.java` | 3 | Reference opponent; preserved. |
+| [#36](https://github.com/T-Py-T/ants-strategy-agent/issues/36) | `src/sample_bots/php/Ants.php` | 9 | Multi-language protocol/reference fixture; preserved. |
+| [#37](https://github.com/T-Py-T/ants-strategy-agent/issues/37) | `src/sample_bots/php/HunterBot.php` | 3 | Reference opponent; preserved. |
+| [#38](https://github.com/T-Py-T/ants-strategy-agent/issues/38) | `src/sample_bots/php/LeftyBot.php` | 3 | Reference opponent; preserved. |
+| [#39](https://github.com/T-Py-T/ants-strategy-agent/issues/39) | `src/sample_bots/php/MyBot.php` | 2 | Reference opponent; preserved. |
+| [#40](https://github.com/T-Py-T/ants-strategy-agent/issues/40) | `src/sample_bots/php/RandomBot.php` | 2 | Reference opponent; preserved. |
+| [#41](https://github.com/T-Py-T/ants-strategy-agent/issues/41) | `src/sample_bots/python/ants.py` | 6 | Protocol/reference fixture shared by sample opponents; preserved. |
+| [#42](https://github.com/T-Py-T/ants-strategy-agent/issues/42) | `src/sample_bots/python/ErrorBot.py` | 3 | Deliberately failing engine-error fixture; preserved. |
+| [#43](https://github.com/T-Py-T/ants-strategy-agent/issues/43) | `src/sample_bots/python/GreedyBot.py` | 5 | Reference opponent; preserved. |
+| [#44](https://github.com/T-Py-T/ants-strategy-agent/issues/44) | `src/sample_bots/python/HoldBot.py` | 2 | Reference opponent; preserved. |
+| [#45](https://github.com/T-Py-T/ants-strategy-agent/issues/45) | `src/sample_bots/python/HunterBot.py` | 2 | Reference opponent; preserved. |
+| [#46](https://github.com/T-Py-T/ants-strategy-agent/issues/46) | `src/sample_bots/python/InvalidBot.py` | 1 | Deliberately invalid engine-protocol fixture; preserved. |
+| [#47](https://github.com/T-Py-T/ants-strategy-agent/issues/47) | `src/sample_bots/python/LeftyBot.py` | 6 | Reference opponent; preserved. |
+| [#48](https://github.com/T-Py-T/ants-strategy-agent/issues/48) | `src/sample_bots/python/logutils.py` | 2 | Support code for sample/reference opponents; preserved. |
+| [#49](https://github.com/T-Py-T/ants-strategy-agent/issues/49) | `src/sample_bots/python/RandomBot.py` | 2 | Reference opponent; preserved. |
+| [#50](https://github.com/T-Py-T/ants-strategy-agent/issues/50) | `src/sample_bots/python/TimeoutBot.py` | 1 | Deliberately timing-out engine fixture; preserved. |
+| [#51](https://github.com/T-Py-T/ants-strategy-agent/issues/51) | `src/tools/mapgen/asymmetric_mapgen.py` | 14 | Fixed all findings. |
+| [#52](https://github.com/T-Py-T/ants-strategy-agent/issues/52) | `src/tools/mapgen/heightmap.py` | 5 | Fixed three safe findings. Deferred two seed-sensitive algorithm complexity rewrites pending golden map fixtures. |
+| [#53](https://github.com/T-Py-T/ants-strategy-agent/issues/53) | `src/tools/mapgen/map.py` | 18 | Fixed 15 safe findings, including exception specificity and the swallowed indexing error. Deferred two complexity rewrites and the public `map` field rename because all generators depend on that interface. |
+| [#54](https://github.com/T-Py-T/ants-strategy-agent/issues/54) | `src/tools/mapgen/mapgen.py` | 34 | Fixed all 28 mechanical findings. Deferred six seed-sensitive algorithm/CLI complexity rewrites pending golden map fixtures. |
+| [#55](https://github.com/T-Py-T/ants-strategy-agent/issues/55) | `src/tools/mapgen/MapWalker.java` | 9 | Fixed eight safe modifier, cast, stack, and boolean-flow findings. Kept the default package because relocation would break direct compilation with sibling generators. |
+| [#56](https://github.com/T-Py-T/ants-strategy-agent/issues/56) | `src/tools/mapgen/random_map.py` | 1 | Fixed the wildcard import. |
+| [#57](https://github.com/T-Py-T/ants-strategy-agent/issues/57) | `src/tools/mapgen/symmetric_mapgen.py` | 8 | Fixed seven mechanical findings. Deferred one seed-sensitive algorithm complexity rewrite pending golden map fixtures. |
+| [#58](https://github.com/T-Py-T/ants-strategy-agent/issues/58) | `src/tools/mapgen/Test.java` | 3 | Removed the stale commented-out call. `System.out` is the manual harness output, and the default package preserves direct sibling compilation. |
+| [#59](https://github.com/T-Py-T/ants-strategy-agent/issues/59) | `src/tools/playgame.py` | 3 | Fixed the broad import catch and duplicate log-name literal. Deferred the monolithic CLI orchestration rewrite pending golden end-to-end games. |
+| [#60](https://github.com/T-Py-T/ants-strategy-agent/issues/60) | `visualizer/js/Ant.js` | 10 | Bundled upstream visualizer; preserved under the compatibility policy above. |
+| [#61](https://github.com/T-Py-T/ants-strategy-agent/issues/61) | `visualizer/js/Application.js` | 133 | Bundled upstream visualizer; preserved under the compatibility policy above. |
+| [#62](https://github.com/T-Py-T/ants-strategy-agent/issues/62) | `visualizer/js/Buttons.js` | 34 | Bundled upstream visualizer; preserved under the compatibility policy above. |
+| [#63](https://github.com/T-Py-T/ants-strategy-agent/issues/63) | `visualizer/js/Config.js` | 11 | Bundled upstream visualizer; preserved under the compatibility policy above. |
+| [#64](https://github.com/T-Py-T/ants-strategy-agent/issues/64) | `visualizer/js/Const.js` | 16 | Bundled upstream visualizer; preserved under the compatibility policy above. |
+| [#65](https://github.com/T-Py-T/ants-strategy-agent/issues/65) | `visualizer/js/Director.js` | 14 | Bundled upstream visualizer; preserved under the compatibility policy above. |
+| [#66](https://github.com/T-Py-T/ants-strategy-agent/issues/66) | `visualizer/js/ImageManager.js` | 12 | Bundled upstream visualizer; preserved under the compatibility policy above. |
+| [#67](https://github.com/T-Py-T/ants-strategy-agent/issues/67) | `visualizer/js/Replay.js` | 97 | Bundled upstream visualizer; preserved under the compatibility policy above. |
+| [#68](https://github.com/T-Py-T/ants-strategy-agent/issues/68) | `visualizer/js/Util.js` | 36 | Bundled upstream visualizer; preserved under the compatibility policy above. |
+| [#69](https://github.com/T-Py-T/ants-strategy-agent/issues/69) | `visualizer/js/visualizer.js` | 11 | Bundled upstream visualizer; preserved under the compatibility policy above. |
 
 ## Verification requirements
 

--- a/docs/gitroll-triage.md
+++ b/docs/gitroll-triage.md
@@ -15,7 +15,8 @@ findings are counted once across those two issue bodies.
   structure cleanup. Seed-sensitive control flow, unfinished algorithms, CLI
   output, and default-package launch contracts remain explicitly dispositioned.
 - `docs/reference/xathis/` is the preserved source of the 2011 winning bot. It is
-  evidence for the Python port, not a maintained Java application.
+  evidence for the partial Python reimplementation, not a maintained Java
+  application.
 - `src/sample_bots/` contains protocol opponents and deliberate failure fixtures
   (`ErrorBot`, `InvalidBot`, and `TimeoutBot`). Cross-language packaging and broad
   cleanup would weaken their value as original, directly executable fixtures.
@@ -30,7 +31,7 @@ findings are counted once across those two issue bodies.
 | --- | ---: | --- |
 | Corrected in code | 251 | Correctness defects and safe smells removed; tests updated where interfaces changed. |
 | Explicit engineering deferral | 72 | Seed/game-sensitive complexity or unfinished utility behavior; rationale recorded per issue below. |
-| Preserved Xathis reference | 338 | Historical ground-truth Java source remains byte-for-byte stable. |
+| Preserved Xathis reference | 338 | Historical Java source remains byte-for-byte stable. |
 | Preserved sample fixtures | 100 | Original multi-language opponents and deliberate protocol failures remain stable. |
 | Preserved upstream visualizer | 455 | Legacy global-script/browser behavior remains stable. |
 | **Total** | **1,216** | Every finding is either fixed or explicitly dispositioned. |
@@ -39,8 +40,8 @@ findings are counted once across those two issue bodies.
 
 | Issue | File | Findings | Disposition |
 | --- | --- | ---: | --- |
-| [#7](https://github.com/T-Py-T/ants-strategy-agent/issues/7) | `docs/reference/xathis/Strategy.java` (1/2) | 169 | Reference snapshot; preserved as ground truth for the Python port. |
-| [#8](https://github.com/T-Py-T/ants-strategy-agent/issues/8) | `docs/reference/xathis/Strategy.java` (2/2) | 33 | Reference snapshot; preserved as ground truth for the Python port. |
+| [#7](https://github.com/T-Py-T/ants-strategy-agent/issues/7) | `docs/reference/xathis/Strategy.java` (1/2) | 169 | Reference snapshot; preserved as the source for comparison with the partial Python reimplementation. |
+| [#8](https://github.com/T-Py-T/ants-strategy-agent/issues/8) | `docs/reference/xathis/Strategy.java` (2/2) | 33 | Reference snapshot; preserved as the source for comparison with the partial Python reimplementation. |
 | [#9](https://github.com/T-Py-T/ants-strategy-agent/issues/9) | `src/ants/ants.py` | 54 | Fixed 40 safe findings, including the identical attack branch and always-true comparison. Deferred 14 game-engine complexity rewrites pending golden replay equivalence. |
 | [#10](https://github.com/T-Py-T/ants-strategy-agent/issues/10) | `src/sample_bots/java/Tile.java` | 2 | Fixed null-unsafe equality and made the override explicit. Kept the default package so the sample bot sources continue to compile and launch directly from their directory. |
 | [#11](https://github.com/T-Py-T/ants-strategy-agent/issues/11) | `src/tools/mapgen/MapGenerator.java` | 24 | Fixed 21 findings: all three null paths plus 18 safe validation, naming, modifier, append, and array-copy smells. The start-position loop remains unchanged pending deterministic map equivalence; `System.out` is the API's requested map output, and the default package preserves direct sibling compilation. |
@@ -60,7 +61,7 @@ findings are counted once across those two issue bodies.
 | [#25](https://github.com/T-Py-T/ants-strategy-agent/issues/25) | `src/ants/sandbox.py` | 5 | Fixed all findings. |
 | [#26](https://github.com/T-Py-T/ants-strategy-agent/issues/26) | `src/bots/ants.py` | 6 | Fixed three safe findings. Deferred three protocol-parser/direction complexity rewrites to preserve the bot wire contract. |
 | [#27](https://github.com/T-Py-T/ants-strategy-agent/issues/27) | `src/bots/bot.py` | 11 | Fixed nine safe findings, including explicit imports and idiomatic membership checks. Deferred two strategy complexity rewrites pending game-outcome equivalence. |
-| [#28](https://github.com/T-Py-T/ants-strategy-agent/issues/28) | `src/bots/xathis_bot.py` | 17 | Fixed four safe findings and updated direct tests for the narrowed battle helper. Deferred 13 complexity rewrites because this port is the benchmark oracle for the historical winner. |
+| [#28](https://github.com/T-Py-T/ants-strategy-agent/issues/28) | `src/bots/xathis_bot.py` | 17 | Fixed four safe findings and updated direct tests for the narrowed battle helper. Deferred 13 complexity rewrites because the incomplete reimplementation is behavior-sensitive and not validated against the historical winner. |
 | [#29](https://github.com/T-Py-T/ants-strategy-agent/issues/29) | `src/sample_bots/java/Aim.java` | 5 | Multi-language reference opponent; preserved. |
 | [#30](https://github.com/T-Py-T/ants-strategy-agent/issues/30) | `src/sample_bots/java/Ants.java` | 24 | Multi-language protocol/reference fixture; preserved. |
 | [#31](https://github.com/T-Py-T/ants-strategy-agent/issues/31) | `src/sample_bots/java/Bot.java` | 2 | Multi-language protocol/reference fixture; preserved. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,7 @@
 [project]
-name = "antsaibot"
+name = "ants-strategy-agent"
 version = "0.1.0"
-description = "Ants AI Challenge Python Bot and Engine"
-authors = [
-    {name = "Your Name", email = "your.email@example.com"}
-]
+description = "Deterministic Ants strategy agent with a local engine and evaluation harness"
 readme = "README.md"
 requires-python = ">=3.12"
 
@@ -25,7 +22,7 @@ analysis = [
     "scipy>=1.18.0",
 ]
 dev = [
-    "antsaibot[test,analysis]",
+    "ants-strategy-agent[test,analysis]",
 ]
 
 [tool.uv]

--- a/scripts/analyze_results.py
+++ b/scripts/analyze_results.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Advanced Analysis Tool for AntsAIBot Results
+Advanced analysis tool for ants-strategy-agent results
 Loads all game results into memory for fast analysis and validation
 """
 
@@ -325,7 +325,11 @@ class AntsAIAnalyzer:
         # Set up the plotting style
         plt.style.use("seaborn-v0_8")
         fig, axes = plt.subplots(2, 2, figsize=(15, 12))
-        fig.suptitle("AntsAIBot Performance Analysis", fontsize=16, fontweight="bold")
+        fig.suptitle(
+            "ants-strategy-agent performance analysis",
+            fontsize=16,
+            fontweight="bold",
+        )
 
         # 1. Win Rate by Opponent
         win_rates = self.game_data.groupby("test_name")["result"].apply(
@@ -392,7 +396,9 @@ class AntsAIAnalyzer:
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Advanced AntsAIBot Results Analysis")
+    parser = argparse.ArgumentParser(
+        description="Advanced ants-strategy-agent results analysis"
+    )
     parser.add_argument(
         "--file",
         "-f",

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -22,11 +22,11 @@ own ranking (``rank`` field of the game result):
 The script depends on the ``RESULT game_id=...`` line that ``playgame.py``
 prints by default; that contract is locked in by ``tests/test_playgame_result_line.py``.
 """
+
 from __future__ import annotations
 
 import argparse
 import json
-import os
 import random
 import re
 import shlex
@@ -114,13 +114,15 @@ def parse_result_line(stdout: str) -> Optional[GameOutcome]:
     m = matches[-1]  # last RESULT line in case of multi-round
     players = []
     for pm in PLAYER_RE.finditer(m.group("players")):
-        players.append({
-            "idx": int(pm.group("idx")),
-            "name": pm.group("name"),
-            "rank": int(pm.group("rank")),
-            "score": int(pm.group("score")),
-            "status": pm.group("status"),
-        })
+        players.append(
+            {
+                "idx": int(pm.group("idx")),
+                "name": pm.group("name"),
+                "rank": int(pm.group("rank")),
+                "score": int(pm.group("score")),
+                "status": pm.group("status"),
+            }
+        )
     if not players:
         return None
     return GameOutcome(
@@ -165,6 +167,7 @@ def run_one_game(
         cwd=str(REPO_ROOT),
         capture_output=True,
         text=True,
+        check=False,
         timeout=turns * 2 + 60,
     )
     elapsed = time.monotonic() - t0
@@ -175,8 +178,16 @@ def run_one_game(
             game_id=-1,
             turns=0,
             winner="error",
-            players=[{"idx": i, "name": shlex.split(b)[-1], "rank": -1, "score": 0,
-                      "status": "no_result"} for i, b in enumerate(bots)],
+            players=[
+                {
+                    "idx": i,
+                    "name": shlex.split(b)[-1],
+                    "rank": -1,
+                    "score": 0,
+                    "status": "no_result",
+                }
+                for i, b in enumerate(bots)
+            ],
             duration_s=elapsed,
             engine_seed=engine_seed,
             player_seed=player_seed,
@@ -216,14 +227,25 @@ def run_matchup(
         statuses = ",".join(p["status"] for p in outcome.players)
         print(
             "  game {0}/{1}  {2:>5s}  turns={3:<4}  scores=[{4}]  status=[{5}]  ({6:.2f}s)".format(
-                i, games, outcome.outcome_label(), outcome.turns, scores, statuses, outcome.duration_s,
+                i,
+                games,
+                outcome.outcome_label(),
+                outcome.turns,
+                scores,
+                statuses,
+                outcome.duration_s,
             )
         )
         summary.games.append(outcome)
     t = summary.tally()
     print(
         "  → {0} wins / {1} losses / {2} draws / {3} errors  win_rate={4:.0f}%  avg_turns={5:.0f}".format(
-            t["wins"], t["losses"], t["draws"], t["errors"], t["win_rate"], t["avg_turns"],
+            t["wins"],
+            t["losses"],
+            t["draws"],
+            t["errors"],
+            t["win_rate"],
+            t["avg_turns"],
         )
     )
     return summary
@@ -243,31 +265,39 @@ def write_summary(
         f"Master seed: {master_seed}",
         "",
     ]
-    lines.append("| Matchup | Wins | Losses | Draws | Errors | Win % | Avg turns | Avg time |")
+    lines.append(
+        "| Matchup | Wins | Losses | Draws | Errors | Win % | Avg turns | Avg time |"
+    )
     lines.append("|---|---:|---:|---:|---:|---:|---:|---:|")
     json_blob = []
     for s in summaries:
         t = s.tally()
         lines.append(
             "| {name} | {wins} | {losses} | {draws} | {errors} | {win_rate:.0f}% | {avg_turns:.0f} | {avg_time:.1f}s |".format(
-                name=s.name, **t,
+                name=s.name,
+                **t,
             )
         )
-        json_blob.append({
-            "matchup": s.name,
-            "master_seed": master_seed,
-            "tally": t,
-            "games": [{
-                "game_id": g.game_id,
-                "turns": g.turns,
-                "winner": g.winner,
-                "outcome": g.outcome_label(),
-                "duration_s": g.duration_s,
-                "engine_seed": g.engine_seed,
-                "player_seed": g.player_seed,
-                "players": g.players,
-            } for g in s.games],
-        })
+        json_blob.append(
+            {
+                "matchup": s.name,
+                "master_seed": master_seed,
+                "tally": t,
+                "games": [
+                    {
+                        "game_id": g.game_id,
+                        "turns": g.turns,
+                        "winner": g.winner,
+                        "outcome": g.outcome_label(),
+                        "duration_s": g.duration_s,
+                        "engine_seed": g.engine_seed,
+                        "player_seed": g.player_seed,
+                        "players": g.players,
+                    }
+                    for g in s.games
+                ],
+            }
+        )
     summary_path.write_text("\n".join(lines) + "\n")
     json_path.write_text(json.dumps(json_blob, indent=2) + "\n")
     return summary_path
@@ -277,25 +307,47 @@ def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
     p = argparse.ArgumentParser(
         description="Benchmark ants-strategy-agent vs sample bots."
     )
-    p.add_argument("--bot", default="src/bots/bot.py",
-                   help="Path to the bot under test (default: src/bots/bot.py)")
-    p.add_argument("--games", type=int, default=5,
-                   help="Games per matchup (default: 5)")
-    p.add_argument("--turns", type=int, default=1000,
-                   help="Maximum turns per game (default: 1000)")
-    p.add_argument("--map", default="maps/maze/maze_02p_01.map",
-                   help="Map for 2-player matchups")
-    p.add_argument("--map-4p", default="maps/maze/maze_04p_01.map",
-                   help="Map for the 4-player matchup")
-    p.add_argument("--seed", type=int, default=None,
-                   help="Master seed used to derive both per-game seeds "
-                        "(default: generated and reported)")
-    p.add_argument("--log-dir", default="game_logs",
-                   help="Where playgame.py writes per-game replay/log files")
-    p.add_argument("--output-dir", default="benchmark_results",
-                   help="Where summary markdown and json land")
-    p.add_argument("--quick", action="store_true",
-                   help="Quick smoke-suite: 2 games per matchup, 200 turns")
+    p.add_argument(
+        "--bot",
+        default="src/bots/bot.py",
+        help="Path to the bot under test (default: src/bots/bot.py)",
+    )
+    p.add_argument(
+        "--games", type=int, default=5, help="Games per matchup (default: 5)"
+    )
+    p.add_argument(
+        "--turns", type=int, default=1000, help="Maximum turns per game (default: 1000)"
+    )
+    p.add_argument(
+        "--map", default="maps/maze/maze_02p_01.map", help="Map for 2-player matchups"
+    )
+    p.add_argument(
+        "--map-4p",
+        default="maps/maze/maze_04p_01.map",
+        help="Map for the 4-player matchup",
+    )
+    p.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="Master seed used to derive both per-game seeds "
+        "(default: generated and reported)",
+    )
+    p.add_argument(
+        "--log-dir",
+        default="game_logs",
+        help="Where playgame.py writes per-game replay/log files",
+    )
+    p.add_argument(
+        "--output-dir",
+        default="benchmark_results",
+        help="Where summary markdown and json land",
+    )
+    p.add_argument(
+        "--quick",
+        action="store_true",
+        help="Quick smoke-suite: 2 games per matchup, 200 turns",
+    )
     return p.parse_args(argv)
 
 
@@ -323,14 +375,22 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
 
     matchups = [
         ("vs_RandomBot", [bot, f"{sample}/RandomBot.py"], map_file),
-        ("vs_HoldBot",   [bot, f"{sample}/HoldBot.py"],   map_file),
+        ("vs_HoldBot", [bot, f"{sample}/HoldBot.py"], map_file),
         ("vs_HunterBot", [bot, f"{sample}/HunterBot.py"], map_file),
         ("vs_GreedyBot", [bot, f"{sample}/GreedyBot.py"], map_file),
-        ("vs_LeftyBot",  [bot, f"{sample}/LeftyBot.py"],  map_file),
+        ("vs_LeftyBot", [bot, f"{sample}/LeftyBot.py"], map_file),
         # Partial local Xathis reimplementation used as a regression opponent.
         ("vs_XathisBot", [bot, xathis], map_file),
-        ("Four_Player",  [bot, f"{sample}/RandomBot.py",
-                          f"{sample}/HunterBot.py", f"{sample}/GreedyBot.py"], map_4p),
+        (
+            "Four_Player",
+            [
+                bot,
+                f"{sample}/RandomBot.py",
+                f"{sample}/HunterBot.py",
+                f"{sample}/GreedyBot.py",
+            ],
+            map_4p,
+        ),
     ]
 
     print("ants-strategy-agent benchmark suite")
@@ -347,20 +407,32 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         if not mp.exists():
             print("  [skip] {0}: map not found at {1}".format(name, mp))
             continue
-        summaries.append(run_matchup(
-            name=name, bots=bots, map_file=mp, games=args.games,
-            log_dir=log_dir, turns=args.turns, rng=rng,
-        ))
+        summaries.append(
+            run_matchup(
+                name=name,
+                bots=bots,
+                map_file=mp,
+                games=args.games,
+                log_dir=log_dir,
+                turns=args.turns,
+                rng=rng,
+            )
+        )
 
-    summary_path = write_summary(
-        summaries, REPO_ROOT / args.output_dir, master_seed
-    )
-    print("\nSummary written to {0}".format(summary_path.relative_to(REPO_ROOT)))
+    summary_path = write_summary(summaries, REPO_ROOT / args.output_dir, master_seed)
+    try:
+        display_path = summary_path.relative_to(REPO_ROOT)
+    except ValueError:
+        display_path = summary_path
+    print("\nSummary written to {0}".format(display_path))
 
     overall_wins = sum(s.tally()["wins"] for s in summaries)
     overall_total = sum(len(s.games) for s in summaries) or 1
-    print("Overall: {0}/{1} wins ({2:.0f}%)".format(
-        overall_wins, overall_total, 100.0 * overall_wins / overall_total))
+    print(
+        "Overall: {0}/{1} wins ({2:.0f}%)".format(
+            overall_wins, overall_total, 100.0 * overall_wins / overall_total
+        )
+    )
     return 0
 
 

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Run head-to-head benchmarks for the user's bot vs the sample bots.
+"""Run head-to-head benchmarks for ants-strategy-agent.
 
 This replaces the legacy ``scripts/benchmark.sh`` which had a broken
 score-parsing path (every game came out as a draw because the shell heredoc
@@ -57,6 +57,8 @@ class GameOutcome:
     winner: str
     players: List[dict]
     duration_s: float
+    engine_seed: Optional[int] = None
+    player_seed: Optional[int] = None
     raw_stdout: str = ""
 
     @property
@@ -136,14 +138,17 @@ def run_one_game(
     map_file: Path,
     log_dir: Path,
     turns: int,
-    seed: int,
+    engine_seed: int,
+    player_seed: int,
     end_wait: float = 0.1,
 ) -> GameOutcome:
     cmd = [
         sys.executable,
         str(PLAYGAME),
+        "--engine_seed",
+        str(engine_seed),
         "--player_seed",
-        str(seed),
+        str(player_seed),
         "--end_wait={0}".format(end_wait),
         "--log_dir",
         str(log_dir),
@@ -173,10 +178,14 @@ def run_one_game(
             players=[{"idx": i, "name": shlex.split(b)[-1], "rank": -1, "score": 0,
                       "status": "no_result"} for i, b in enumerate(bots)],
             duration_s=elapsed,
+            engine_seed=engine_seed,
+            player_seed=player_seed,
             raw_stdout=proc.stdout + "\n--- stderr ---\n" + proc.stderr,
         )
     else:
         outcome.duration_s = elapsed
+        outcome.engine_seed = engine_seed
+        outcome.player_seed = player_seed
     return outcome
 
 
@@ -193,13 +202,15 @@ def run_matchup(
     print("\n[matchup] {0}  ({1} games on {2})".format(name, games, map_file.name))
     summary = MatchupSummary(name=name)
     for i in range(1, games + 1):
-        seed = rng.randint(1, 1_000_000)
+        engine_seed = rng.randint(1, 1_000_000)
+        player_seed = rng.randint(1, 1_000_000)
         outcome = run_one_game(
             bots=bots,
             map_file=map_file,
             log_dir=log_dir,
             turns=turns,
-            seed=seed,
+            engine_seed=engine_seed,
+            player_seed=player_seed,
         )
         scores = ",".join(str(p["score"]) for p in outcome.players)
         statuses = ",".join(p["status"] for p in outcome.players)
@@ -218,12 +229,20 @@ def run_matchup(
     return summary
 
 
-def write_summary(summaries: Iterable[MatchupSummary], output_dir: Path) -> Path:
+def write_summary(
+    summaries: Iterable[MatchupSummary], output_dir: Path, master_seed: int
+) -> Path:
     output_dir.mkdir(parents=True, exist_ok=True)
     timestamp = time.strftime("%Y-%m-%d_%H-%M-%S")
     summary_path = output_dir / f"summary_{timestamp}.md"
     json_path = output_dir / f"summary_{timestamp}.json"
-    lines = ["# AntsAIBot benchmark summary", "", f"Generated: {timestamp}", ""]
+    lines = [
+        "# ants-strategy-agent benchmark summary",
+        "",
+        f"Generated: {timestamp}",
+        f"Master seed: {master_seed}",
+        "",
+    ]
     lines.append("| Matchup | Wins | Losses | Draws | Errors | Win % | Avg turns | Avg time |")
     lines.append("|---|---:|---:|---:|---:|---:|---:|---:|")
     json_blob = []
@@ -236,6 +255,7 @@ def write_summary(summaries: Iterable[MatchupSummary], output_dir: Path) -> Path
         )
         json_blob.append({
             "matchup": s.name,
+            "master_seed": master_seed,
             "tally": t,
             "games": [{
                 "game_id": g.game_id,
@@ -243,6 +263,8 @@ def write_summary(summaries: Iterable[MatchupSummary], output_dir: Path) -> Path
                 "winner": g.winner,
                 "outcome": g.outcome_label(),
                 "duration_s": g.duration_s,
+                "engine_seed": g.engine_seed,
+                "player_seed": g.player_seed,
                 "players": g.players,
             } for g in s.games],
         })
@@ -252,7 +274,9 @@ def write_summary(summaries: Iterable[MatchupSummary], output_dir: Path) -> Path
 
 
 def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
-    p = argparse.ArgumentParser(description="Benchmark AntsAIBot vs sample bots.")
+    p = argparse.ArgumentParser(
+        description="Benchmark ants-strategy-agent vs sample bots."
+    )
     p.add_argument("--bot", default="src/bots/bot.py",
                    help="Path to the bot under test (default: src/bots/bot.py)")
     p.add_argument("--games", type=int, default=5,
@@ -264,7 +288,8 @@ def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
     p.add_argument("--map-4p", default="maps/maze/maze_04p_01.map",
                    help="Map for the 4-player matchup")
     p.add_argument("--seed", type=int, default=None,
-                   help="Master seed for reproducibility (default: random)")
+                   help="Master seed used to derive both per-game seeds "
+                        "(default: generated and reported)")
     p.add_argument("--log-dir", default="game_logs",
                    help="Where playgame.py writes per-game replay/log files")
     p.add_argument("--output-dir", default="benchmark_results",
@@ -280,7 +305,12 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         args.games = 2
         args.turns = 200
 
-    rng = random.Random(args.seed)
+    master_seed = (
+        args.seed
+        if args.seed is not None
+        else random.SystemRandom().randint(1, 2**63 - 1)
+    )
+    rng = random.Random(master_seed)
     bot = "{0} {1}".format(sys.executable, args.bot)
     sample = "{0} src/sample_bots/python".format(sys.executable)
 
@@ -297,18 +327,18 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         ("vs_HunterBot", [bot, f"{sample}/HunterBot.py"], map_file),
         ("vs_GreedyBot", [bot, f"{sample}/GreedyBot.py"], map_file),
         ("vs_LeftyBot",  [bot, f"{sample}/LeftyBot.py"],  map_file),
-        # The "final boss": our port of the AI Challenge 2011 winner.
-        # Beating xathis_bot is the long-term goal for any ML successor.
+        # Partial local Xathis reimplementation used as a regression opponent.
         ("vs_XathisBot", [bot, xathis], map_file),
         ("Four_Player",  [bot, f"{sample}/RandomBot.py",
                           f"{sample}/HunterBot.py", f"{sample}/GreedyBot.py"], map_4p),
     ]
 
-    print("AntsAIBot benchmark suite")
-    print("=========================")
+    print("ants-strategy-agent benchmark suite")
+    print("===================================")
     print("Bot under test : {0}".format(args.bot))
     print("Games/matchup  : {0}".format(args.games))
     print("Turn limit     : {0}".format(args.turns))
+    print("Master seed    : {0}".format(master_seed))
     print("2P map         : {0}".format(args.map))
     print("4P map         : {0}".format(args.map_4p))
 
@@ -322,7 +352,9 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             log_dir=log_dir, turns=args.turns, rng=rng,
         ))
 
-    summary_path = write_summary(summaries, REPO_ROOT / args.output_dir)
+    summary_path = write_summary(
+        summaries, REPO_ROOT / args.output_dir, master_seed
+    )
     print("\nSummary written to {0}".format(summary_path.relative_to(REPO_ROOT)))
 
     overall_wins = sum(s.tally()["wins"] for s in summaries)

--- a/scripts/docker_test.sh
+++ b/scripts/docker_test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Docker-based testing script for AntsAIBot
+# Docker-based testing script for ants-strategy-agent
 # Provides consistent testing environment across different systems
 
 set -e
@@ -12,15 +12,15 @@ BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
 # Configuration
-IMAGE_NAME="antsaibot"
-CONTAINER_NAME="antsaibot-test"
+IMAGE_NAME="ants-strategy-agent"
+CONTAINER_NAME="ants-strategy-agent-test"
 LOG_DIR="game_logs"
 
 # Resolve which container engine to use. Prefer podman when present,
 # otherwise docker. Override by exporting CONTAINER_ENGINE=docker.
 ENGINE="${CONTAINER_ENGINE:-$(command -v podman >/dev/null 2>&1 && echo podman || echo docker)}"
 
-echo -e "${BLUE}AntsAIBot Docker Testing${NC}"
+echo -e "${BLUE}ants-strategy-agent Docker testing${NC}"
 echo "========================="
 echo ""
 

--- a/scripts/run_parallel_stats.sh
+++ b/scripts/run_parallel_stats.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Parallel statistics script for AntsAIBot
+# Parallel statistics script for ants-strategy-agent
 # Runs hundreds of games in parallel for fast statistical analysis
 
 set -e
@@ -22,7 +22,7 @@ MAX_PARALLEL=${MAX_PARALLEL:-10}  # Maximum parallel games
 # Create log directory if it doesn't exist
 mkdir -p "$LOG_DIR"
 
-echo -e "${BLUE}AntsAIBot Parallel Statistics Runner${NC}"
+echo -e "${BLUE}ants-strategy-agent parallel statistics runner${NC}"
 echo "======================================="
 echo "Timestamp: $TIMESTAMP"
 echo "Games per test: $GAMES_PER_TEST"

--- a/scripts/run_statistics.sh
+++ b/scripts/run_statistics.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Statistics script for AntsAIBot
+# Statistics script for ants-strategy-agent
 # Runs multiple games and shows only final statistics
 
 set -e
@@ -21,7 +21,7 @@ TURNS_PER_GAME=${TURNS_PER_GAME:-1000}
 # Create log directory if it doesn't exist
 mkdir -p "$LOG_DIR"
 
-echo -e "${BLUE}AntsAIBot Statistics Runner${NC}"
+echo -e "${BLUE}ants-strategy-agent statistics runner${NC}"
 echo "=============================="
 echo "Timestamp: $TIMESTAMP"
 echo "Games per test: $GAMES_PER_TEST"
@@ -133,7 +133,7 @@ run_statistics() {
 }
 
 # Initialize statistics file
-echo "AntsAIBot Statistics Report - $TIMESTAMP" > "$STATS_FILE"
+echo "ants-strategy-agent statistics report - $TIMESTAMP" > "$STATS_FILE"
 echo "=======================================" >> "$STATS_FILE"
 echo "" >> "$STATS_FILE"
 

--- a/scripts/run_statistics_json.sh
+++ b/scripts/run_statistics_json.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Statistics script for AntsAIBot using JSON output
+# Statistics script for ants-strategy-agent using JSON output
 # Runs multiple games and shows only final statistics
 
 set -e
@@ -28,7 +28,7 @@ fi
 # Create log directory if it doesn't exist
 mkdir -p "$LOG_DIR"
 
-echo -e "${BLUE}AntsAIBot Statistics Runner (JSON)${NC}"
+echo -e "${BLUE}ants-strategy-agent statistics runner (JSON)${NC}"
 echo "====================================="
 echo "Timestamp: $TIMESTAMP"
 echo "Games per test: $GAMES_PER_TEST"

--- a/scripts/test_suite.sh
+++ b/scripts/test_suite.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# full test suite for AntsAIBot
+# full test suite for ants-strategy-agent
 # Runs multiple test scenarios and generates a report
 
 set -e
@@ -19,13 +19,13 @@ TIMESTAMP=$(date +"%Y-%m-%d_%H-%M-%S")
 # Create log directory if it doesn't exist
 mkdir -p "$LOG_DIR"
 
-echo -e "${BLUE}AntsAIBot Test Suite${NC}"
+echo -e "${BLUE}ants-strategy-agent test suite${NC}"
 echo "====================="
 echo "Timestamp: $TIMESTAMP"
 echo ""
 
 # Initialize report
-echo "AntsAIBot Test Report - $TIMESTAMP" > "$REPORT_FILE"
+echo "ants-strategy-agent test report - $TIMESTAMP" > "$REPORT_FILE"
 echo "=================================" >> "$REPORT_FILE"
 echo "" >> "$REPORT_FILE"
 

--- a/src/bots/xathis_bot.py
+++ b/src/bots/xathis_bot.py
@@ -1,16 +1,16 @@
 #!/usr/bin/env python
-"""XathisBot — a Python port of the AI Challenge 2011 winning bot.
+"""Incomplete Python reimplementation of the 2011 winning Xathis bot.
 
 The original is in ``docs/reference/xathis/Strategy.java`` (1,773 lines) and
 the postmortem is at ``docs/reference/xathis/postmortem.txt``.
 
-This is V1: scaffolding only. It puts the full data model in place
-(``Tile`` / ``Ant`` / torus geometry / combat distances) and the empty
-phase ladder from ``Strategy.actions()``. Every phase is a stub that
-returns immediately; the bot falls back to a trivial "all ants stay
-put" behaviour so it never crashes the engine.
+The data model, phase ladder, and several strategy phases have been adapted,
+but multiple phases remain stubs and combat uses a simplified bounded search.
+The implementation is playable and tested for its implemented behavior; it has
+not been validated as strategically faithful or equivalent in strength to the
+preserved Java bot.
 
-Subsequent commits fill in one phase at a time, in this order:
+The phase ladder follows this order:
 
     initTurn        bookkeeping, dangered/willStay flags, gammaDistEnemies
     food            multi-source BFS from food tiles
@@ -287,10 +287,7 @@ class Mission:
 # XathisBot
 # ---------------------------------------------------------------------------
 class XathisBot:
-    """Faithful Python port of xathis's AI Challenge 2011 winning bot.
-
-    Used as the "final boss" opponent for AdvancedBot and future
-    ML-driven variants in this repo.
+    """Partial Python reimplementation of the 2011 Xathis bot.
 
     The phase ladder in ``do_turn`` mirrors ``Strategy.actions()``
     (Strategy.java:203). Each phase is one method on this class; phases

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-"""Shared pytest fixtures and path setup for the AntsAIBot test suite."""
+"""Shared pytest fixtures and path setup for ants-strategy-agent tests."""
 
 from __future__ import annotations
 

--- a/tests/test_advanced_bot.py
+++ b/tests/test_advanced_bot.py
@@ -31,7 +31,9 @@ def _load_bot_module():
     """
 
     bot_path = REPO_ROOT / "src" / "bots" / "bot.py"
-    spec = importlib.util.spec_from_file_location("antsaibot_bot_under_test", bot_path)
+    spec = importlib.util.spec_from_file_location(
+        "ants_strategy_agent_bot_under_test", bot_path
+    )
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     saved = sys.modules.get("ants")

--- a/tests/test_advanced_bot.py
+++ b/tests/test_advanced_bot.py
@@ -15,7 +15,6 @@ import pytest
 from bots import ants as bot_helper_ants
 from bots.ants import AIM, BEHIND, LEFT, RIGHT
 
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
@@ -233,8 +232,7 @@ class TestAdvancedBotDoTurn:
         )
         bot.do_turn(ants)
         destinations = [
-            ants.destination(row, col, direction)
-            for row, col, direction in ants.orders
+            ants.destination(row, col, direction) for row, col, direction in ants.orders
         ]
         assert len(destinations) == len(set(destinations))
 

--- a/tests/test_analyze_results.py
+++ b/tests/test_analyze_results.py
@@ -121,7 +121,9 @@ def synthetic_results(tmp_path: Path) -> Path:
 
 
 class TestAntsAIAnalyzerLoading:
-    def test_loads_synthetic_results(self, analyzer_module, synthetic_results: Path) -> None:
+    def test_loads_synthetic_results(
+        self, analyzer_module, synthetic_results: Path
+    ) -> None:
         analyzer = analyzer_module.AntsAIAnalyzer(str(synthetic_results))
         assert len(analyzer.df) == 2
         # 4 + 2 game-level rows expected

--- a/tests/test_analyze_results.py
+++ b/tests/test_analyze_results.py
@@ -25,7 +25,9 @@ def _load_analyzer_module():
     """Import scripts/analyze_results.py by file path (it isn't a package)."""
 
     path = REPO_ROOT / "scripts" / "analyze_results.py"
-    spec = importlib.util.spec_from_file_location("antsaibot_analyze_results", path)
+    spec = importlib.util.spec_from_file_location(
+        "ants_strategy_agent_analyze_results", path
+    )
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)

--- a/tests/test_benchmark_parser.py
+++ b/tests/test_benchmark_parser.py
@@ -60,14 +60,17 @@ SAMPLE_4P_DRAW = (
 )
 
 
-@pytest.mark.parametrize("line,expected_outcome", [
-    (SAMPLE_WIN, "WIN"),
-    (SAMPLE_LOSS, "LOSS"),
-    (SAMPLE_DRAW, "DRAW"),
-    (SAMPLE_4P_WIN, "WIN"),
-    # 4-player tie that includes player_0 → DRAW (player_0 still on top)
-    (SAMPLE_4P_DRAW, "DRAW"),
-])
+@pytest.mark.parametrize(
+    "line,expected_outcome",
+    [
+        (SAMPLE_WIN, "WIN"),
+        (SAMPLE_LOSS, "LOSS"),
+        (SAMPLE_DRAW, "DRAW"),
+        (SAMPLE_4P_WIN, "WIN"),
+        # 4-player tie that includes player_0 → DRAW (player_0 still on top)
+        (SAMPLE_4P_DRAW, "DRAW"),
+    ],
+)
 def test_outcome_classification(benchmark_mod, line, expected_outcome):
     outcome = benchmark_mod.parse_result_line(line)
     assert outcome is not None
@@ -134,12 +137,10 @@ def test_matchup_summary_tally(benchmark_mod):
     assert t["win_rate"] == 50.0
 
 
-def test_run_one_game_forwards_both_seeds(
-    benchmark_mod, monkeypatch, tmp_path
-):
+def test_run_one_game_forwards_both_seeds(benchmark_mod, monkeypatch, tmp_path):
     captured = {}
 
-    def fake_run(cmd, **kwargs):
+    def fake_run(cmd, **_kwargs):
         captured["cmd"] = cmd
         return SimpleNamespace(stdout=SAMPLE_WIN, stderr="", returncode=0)
 
@@ -161,25 +162,39 @@ def test_run_one_game_forwards_both_seeds(
     assert outcome.player_seed == 29
 
 
-def test_summary_records_master_and_per_game_seeds(
-    benchmark_mod, tmp_path
-):
+def test_summary_records_master_and_per_game_seeds(benchmark_mod, tmp_path):
     outcome = benchmark_mod.parse_result_line(SAMPLE_WIN)
     assert outcome is not None
     outcome.engine_seed = 17
     outcome.player_seed = 29
-    summary = benchmark_mod.MatchupSummary(
-        name="vs_RandomBot", games=[outcome]
-    )
+    summary = benchmark_mod.MatchupSummary(name="vs_RandomBot", games=[outcome])
 
-    markdown_path = benchmark_mod.write_summary(
-        [summary], tmp_path, master_seed=41
-    )
-    json_payload = json.loads(
-        markdown_path.with_suffix(".json").read_text()
-    )
+    markdown_path = benchmark_mod.write_summary([summary], tmp_path, master_seed=41)
+    json_payload = json.loads(markdown_path.with_suffix(".json").read_text())
 
     assert "Master seed: 41" in markdown_path.read_text()
     assert json_payload[0]["master_seed"] == 41
     assert json_payload[0]["games"][0]["engine_seed"] == 17
     assert json_payload[0]["games"][0]["player_seed"] == 29
+
+
+def test_main_reports_summary_outside_repo(benchmark_mod, tmp_path, capsys):
+    output_dir = tmp_path / "benchmark-results"
+    result = benchmark_mod.main(
+        [
+            "--games",
+            "0",
+            "--seed",
+            "42",
+            "--log-dir",
+            str(tmp_path / "game-logs"),
+            "--output-dir",
+            str(output_dir),
+        ]
+    )
+
+    assert result == 0
+    captured = capsys.readouterr().out
+    assert f"Summary written to {output_dir}" in captured
+    assert list(output_dir.glob("summary_*.md"))
+    assert list(output_dir.glob("summary_*.json"))

--- a/tests/test_benchmark_parser.py
+++ b/tests/test_benchmark_parser.py
@@ -1,16 +1,17 @@
-"""Tests for ``scripts/benchmark.py`` — RESULT-line parsing only.
+"""Tests for benchmark result parsing and reproducibility contracts.
 
 Running real games is covered by ``test_playgame_result_line.py``; this
-module asserts the regex / outcome-classification logic is correct. That's
-where the legacy bash benchmark broke (every game came back as a draw).
+module exercises the lightweight parsing, command, and summary boundaries.
 """
 
 from __future__ import annotations
 
 import importlib
 import importlib.util
+import json
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -131,3 +132,54 @@ def test_matchup_summary_tally(benchmark_mod):
     assert t["draws"] == 1
     assert t["errors"] == 0
     assert t["win_rate"] == 50.0
+
+
+def test_run_one_game_forwards_both_seeds(
+    benchmark_mod, monkeypatch, tmp_path
+):
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return SimpleNamespace(stdout=SAMPLE_WIN, stderr="", returncode=0)
+
+    monkeypatch.setattr(benchmark_mod.subprocess, "run", fake_run)
+
+    outcome = benchmark_mod.run_one_game(
+        bots=["python bot.py", "python opponent.py"],
+        map_file=tmp_path / "map.map",
+        log_dir=tmp_path,
+        turns=30,
+        engine_seed=17,
+        player_seed=29,
+    )
+
+    cmd = captured["cmd"]
+    assert cmd[cmd.index("--engine_seed") + 1] == "17"
+    assert cmd[cmd.index("--player_seed") + 1] == "29"
+    assert outcome.engine_seed == 17
+    assert outcome.player_seed == 29
+
+
+def test_summary_records_master_and_per_game_seeds(
+    benchmark_mod, tmp_path
+):
+    outcome = benchmark_mod.parse_result_line(SAMPLE_WIN)
+    assert outcome is not None
+    outcome.engine_seed = 17
+    outcome.player_seed = 29
+    summary = benchmark_mod.MatchupSummary(
+        name="vs_RandomBot", games=[outcome]
+    )
+
+    markdown_path = benchmark_mod.write_summary(
+        [summary], tmp_path, master_seed=41
+    )
+    json_payload = json.loads(
+        markdown_path.with_suffix(".json").read_text()
+    )
+
+    assert "Master seed: 41" in markdown_path.read_text()
+    assert json_payload[0]["master_seed"] == 41
+    assert json_payload[0]["games"][0]["engine_seed"] == 17
+    assert json_payload[0]["games"][0]["player_seed"] == 29

--- a/tests/test_devcontainer.py
+++ b/tests/test_devcontainer.py
@@ -51,9 +51,9 @@ def test_no_deprecated_python_extension_keys(devcontainer: dict) -> None:
 
 def test_modern_lint_and_format_settings_present(devcontainer: dict) -> None:
     settings = devcontainer["customizations"]["vscode"]["settings"]
-    assert settings.get("pylint.enabled") is True, (
-        "modern `pylint.enabled` (from ms-python.pylint) should be true"
-    )
+    assert (
+        settings.get("pylint.enabled") is True
+    ), "modern `pylint.enabled` (from ms-python.pylint) should be true"
     python_lang = settings.get("[python]")
     assert isinstance(python_lang, dict), "missing `[python]` language block"
     assert python_lang.get("editor.defaultFormatter") == "ms-python.black-formatter"
@@ -70,8 +70,7 @@ def test_post_create_command_uses_uv(devcontainer: dict) -> None:
 def test_python_interpreter_points_to_uv_venv(devcontainer: dict) -> None:
     settings = devcontainer["customizations"]["vscode"]["settings"]
     assert (
-        settings["python.defaultInterpreterPath"]
-        == "/app/.venv/bin/python"
+        settings["python.defaultInterpreterPath"] == "/app/.venv/bin/python"
     ), "interpreter path should resolve to the uv-managed venv"
 
 

--- a/tests/test_devcontainer.py
+++ b/tests/test_devcontainer.py
@@ -32,7 +32,7 @@ def devcontainer() -> dict:
 
 
 def test_devcontainer_parses(devcontainer: dict) -> None:
-    assert devcontainer["name"] == "AntsAIBot Development"
+    assert devcontainer["name"] == "ants-strategy-agent development"
     assert devcontainer["workspaceFolder"] == "/app"
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -11,7 +11,7 @@ resolution-markers = [
 ]
 
 [[package]]
-name = "antsaibot"
+name = "ants-strategy-agent"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
@@ -42,7 +42,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "antsaibot", extras = ["test", "analysis"], marker = "extra == 'dev'" },
+    { name = "ants-strategy-agent", extras = ["test", "analysis"], marker = "extra == 'dev'" },
     { name = "colorama", specifier = ">=0.4.6" },
     { name = "matplotlib", marker = "extra == 'analysis'", specifier = ">=3.11.0" },
     { name = "numpy", marker = "extra == 'analysis'", specifier = ">=2.5.0" },


### PR DESCRIPTION
## Intent

Make the currently pinned Ants repository recruiter-show-ready without changing its core behavior: rename and reframe it as ants-strategy-agent, give it 30-second clarity, explain its deterministic engine, evaluation contract, visualization, provenance and honest limitations, retain the user's chosen pin, keep CI pull-request-only to conserve hosted minutes, validate locally, publish through a neutral portfolio/show-ready branch, and prepare a mergeable PR. Taylor has explicitly asked the agent to drive all review gates unattended and merge the completed cleanup without requiring human PR review.

## What Changed

- Rebrand package, container, devcontainer, scripts, and documentation as `ants-strategy-agent`, with a concise README covering architecture, setup, visualization, and PR-only CI.
- Make benchmarks reproducible by deriving and recording engine/player seeds from a master seed, exposing seeded Make targets, and supporting output directories outside the repository.
- Clarify provenance and limitations of the preserved challenge code and partial Xathis reimplementation, with regression coverage for the renamed configuration and benchmark contracts.

## Risk Assessment

✅ Low: The prior naming, determinism, and Xathis-framing defects are fully addressed, and the remaining changes are consistent, well-bounded portfolio and evaluation-harness updates.

## Testing

Focused tests, recruiter-facing CLI checks, two seeded engine runs, two seven-matchup benchmarks, README rendering, CI-trigger validation, branch/pin checks, and cleanup completed successfully; an absolute-output benchmark crash was fixed with regression coverage, and no targeted issues remain.

<details>
<summary>Evidence: Recruiter-facing README render</summary>

```text
<!doctype html>
<html lang="en">
<head>
<meta charset="utf-8">
<meta name="viewport" content="width=device-width, initial-scale=1">
<title>ants-strategy-agent README</title>
<style>/**
 * Minified by jsDelivr using clean-css v5.3.3.
 * Original file: /npm/github-markdown-css@5.8.1/github-markdown.css
 *
 * Do NOT use SRI with dynamically generated files! More information: https://www.jsdelivr.com/using-sri-with-dynamic-files
 */
.markdown-body{--base-size-4:0.25rem;--base-size-8:0.5rem;--base-size-16:1rem;--base-size-24:1.5rem;--base-size-40:2.5rem;--base-text-weight-normal:400;--base-text-weight-medium:500;--base-text-weight-semibold:600;--fontStack-monospace:ui-monospace,SFMono-Regular,SF Mono,Menlo,Consolas,Liberation Mono,monospace;--fgColor-accent:Highlight}@media (prefers-color-scheme:dark){.markdown-body,[data-theme=dark]{color-scheme:dark;--focus-outlineColor:#1f6feb;--fgColor-default:#f0f6fc;--fgColor-muted:#9198a1;--fgColor-accent:#4493f8;--fgColor-success:#3fb950;--fgColor-attention:#d29922;--fgColor-danger:#f85149;--fgColor-done:#ab7df8;--bgColor-default:#0d1117;--bgColor-muted:#151b23;--bgColor-neutral-muted:#656c7633;--bgColor-attention-muted:#bb800926;--borderColor-default:#3d444d;--borderColor-muted:#3d444db3;--borderColor-neutral-muted:#3d444db3;--borderColor-accent-emphasis:#1f6feb;--borderColor-success-emphasis:#238636;--borderColor-attention-emphasis:#9e6a03;--borderColor-danger-emphasis:#da3633;--borderColor-done-emphasis:#8957e5;--color-prettylights-syntax-comment:#9198a1;--color-prettylights-syntax-constant:#79c0ff;--color-prettylights-syntax-constant-other-reference-link:#a5d6ff;--color-prettylights-syntax-entity:#d2a8ff;--color-prettylights-syntax-storage-modifier-import:#f0f6fc;--color-prettylights-syntax-entity-tag:#7ee787;--color-prettylights-syntax-keyword:#ff7b72;--color-prettylights-syntax-string:#a5d6ff;--color-prettylights-syntax-variable:#ffa657;--color-prettylights-syntax-brackethighlighter-unmatched:#f85149;--color-prettylights-syntax-brackethighlighter-angle:#9198a1;--color-prettylights-syntax-invalid-illegal-text:#f0f6fc;--color-prettylights-syntax-invalid-illegal-bg:#8e1519;--color-prettylights-syntax-carriage-return-text:#f0f6fc;--color-prettylights-syntax-carriage-return-bg:#b62324;--color-prettylights-syntax-string-regexp:#7ee787;--color-prettylights-syntax-markup-list:#f2cc60;--color-prettylights-syntax-markup-heading:#1f6feb;--color-prettylights-syntax-markup-italic:#f0f6fc;--color-prettylights-syntax-markup-bold:#f0f6fc;--color-prettylights-syntax-markup-deleted-text:#ffdcd7;--color-prettylights-syntax-markup-deleted-bg:#67060c;--color-prettylights-syntax-markup-inserted-text:#aff5b4;--color-prettylights-syntax-markup-inserted-bg:#033a16;--color-prettylights-syntax-markup-changed-text:#ffdfb6;--color-prettylights-syntax-markup-changed-bg:#5a1e02;--color-prettylights-syntax-markup-ignored-text:#f0f6fc;--color-prettylights-syntax-markup-ignored-bg:#1158c7;--color-prettylights-syntax-meta-diff-range:#d2a8ff;--color-prettylights-syntax-sublimelinter-gutter-mark:#3d444d}}@media (prefers-color-scheme:light){.markdown-body,[data-theme=light]{color-scheme:light;--focus-outlineColor:#0969da;--fgColor-default:#1f2328;--fgColor-muted:#59636e;--fgColor-accent:#0969da;--fgColor-success:#1a7f37;--fgColor-attention:#9a6700;--fgColor-danger:#d1242f;--fgColor-done:#8250df;--bgColor-default:#ffffff;--bgColor-muted:#f6f8fa;--bgColor-neutral-muted:#818b981f;--bgColor-attention-muted:#fff8c5;--borderColor-default:#d1d9e0;--borderColor-muted:#d1d9e0b3;--borderColor-neutral-muted:#d1d9e0b3;--borderColor-accent-emphasis:#0969da;--borderColor-success-emphasis:#1a7f37;--borderColor-attention-emphasis:#9a6700;--borderColor-danger-emphasis:#cf222e;--borderColor-done-emphasis:#8250df;--color-prettylights-syntax-comment:#59636e;--color-prettylights-syntax-constant:#0550ae;--color-prettylights-syntax-constant-other-reference-link:#0a3069;--color-prettylights-syntax-entity:#6639ba;--color-prettylights-syntax-storage-modifier-import:#1f2328;--color-prettylights-syntax-entity-tag:#0550ae;--color-prettylights-syntax-keyword:#cf222e;--color-prettylights-syntax-string:#0a3069;--color-prettylights-syntax-variable:#953800;--color-prettylights-syntax-brackethighlighter-unmatched:#82071e;--color-prettylights-syntax-brackethighlighter-angle:#59636e;--color-prettylights-syntax-invalid-illegal-text:#f6f8fa;--color-prettylights-syntax-invalid-illegal-bg:#82071e;--color-prettylights-syntax-carriage-return-text:#f6f8fa;--color-prettylights-syntax-carriage-return-bg:#cf222e;--color-prettylights-syntax-string-regexp:#116329;--color-prettylights-syntax-markup-list:#3b2300;--color-prettylights-syntax-markup-heading:#0550ae;--color-prettylights-syntax-markup-italic:#1f2328;--color-prettylights-syntax-markup-bold:#1f2328;--color-prettylights-syntax-markup-deleted-text:#82071e;--color-prettylights-syntax-markup-deleted-bg:#ffebe9;--color-prettylights-syntax-markup-inserted-text:#116329;--color-prettylights-syntax-markup-inserted-bg:#dafbe1;--color-prettylights-syntax-markup-changed-text:#953800;--color-prettylights-syntax-markup-changed-bg:#ffd8b5;--color-prettylights-syntax-markup-ignored-text:#d1d9e0;--color-prettylights-syntax-markup-ignored-bg:#0550ae;--color-prettylights-syntax-meta-diff-range:#8250df;--color-prettylights-syntax-sublimelinter-gutter-mark:#818b98}}.markdown-body{-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%;margin:0;color:var(--fgColor-default);background-color:var(--bgColor-default);font-family:-apple-system,BlinkMacSystemFont,"Segoe UI","Noto Sans",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji";font-size:16px;line-height:1.5;word-wrap:break-word}.markdown-body .octicon{display:inline-block;fill:currentColor;vertical-align:text-bottom}.markdown-body h1:hover .anchor .octicon-link:before,.markdown-body h2:hover .anchor .octicon-link:before,.markdown-body h3:hover .anchor .octicon-link:before,.markdown-body h4:hover .anchor .octicon-link:before,.markdown-body h5:hover .anchor .octicon-link:before,.markdown-body h6:hover .anchor .octicon-link:before{width:16px;height:16px;content:' ';display:inline-block;background-color:currentColor;-webkit-mask-image:url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' version='1.1' aria-hidden='true'><path fill-rule='evenodd' d='M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z'></path></svg>");mask-image:url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' version='1.1' aria-hidden='true'><path fill-rule='evenodd' d='M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z'></path></svg>")}.markdown-body details,.markdown-body figcaption,.markdown-body figure{display:block}.markdown-body summary{display:list-item}.markdown-body [hidden]{display:none!important}.markdown-body a{background-color:transparent;color:var(--fgColor-accent);text-decoration:none}.markdown-body abbr[title]{border-bottom:none;-webkit-text-decoration:underline dotted;text-decoration:underline dotted}.markdown-body b,.markdown-body strong{font-weight:var(--base-text-weight-semibold,600)}.markdown-body dfn{font-style:italic}.markdown-body h1{margin:.67em 0;font-weight:var(--base-text-weight-semibold,600);padding-bottom:.3em;font-size:2em;border-bottom:1px solid var(--borderColor-muted)}.markdown-body mark{background-color:var(--bgColor-attention-muted);color:var(--fgColor-default)}.markdown-body small{font-size:90%}.markdown-body sub,.markdown-body sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}.markdown-body sub{bottom:-

... [18811 bytes truncated] ...

600 14px -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; color:#0969da; }
.markdown-body { box-sizing: border-box; min-width: 200px; max-width: 1012px; margin: 0 auto; padding: 32px 45px 64px; }
@media (max-width: 767px) { .markdown-body { padding: 20px 16px 48px; } }
</style>
</head>
<body>
<div class="repo-bar">T-Py-T / ants-strategy-agent</div>
<article class="markdown-body"><h1>ants-strategy-agent</h1>
<p>A deterministic multi-agent strategy system for the 2011 Ants AI Challenge,
packaged with a local game engine, reference opponents, replay visualization,
benchmark tooling, and PR-gated tests.</p>
<p>The engineering focus is the evaluation loop around the bot: run repeatable
matches, inspect replays, compare strategies against fixed opponents, and keep
the engine/protocol boundary covered by tests.</p>
<h2>At a glance</h2>
<table>
<thead>
<tr>
<th>Area</th>
<th>Public evidence</th>
<th>Signal</th>
</tr>
</thead>
<tbody><tr>
<td>Strategy implementation</td>
<td><a href="src/bots/bot.py"><code>src/bots/bot.py</code></a></td>
<td>Hierarchical objectives, persistent orders, collision avoidance, exploration, and combat heuristics</td>
</tr>
<tr>
<td>Game runtime</td>
<td><a href="src/ants"><code>src/ants/</code></a>, <a href="src/tools/playgame.py"><code>src/tools/playgame.py</code></a></td>
<td>Local engine, sandboxing, protocol parsing, and match orchestration</td>
</tr>
<tr>
<td>Evaluation</td>
<td><a href="Makefile"><code>Makefile</code></a>, <a href="scripts/benchmark.py"><code>scripts/benchmark.py</code></a></td>
<td>Named head-to-head, probabilistic, and benchmark entry points</td>
</tr>
<tr>
<td>Regression protection</td>
<td><a href="tests"><code>tests/</code></a>, <a href=".github/workflows/ci.yml">PR workflow</a></td>
<td>Unit, protocol, engine, sample-bot, Docker, and real-game checks</td>
</tr>
<tr>
<td>Qualitative debugging</td>
<td><a href="visualizer"><code>visualizer/</code></a></td>
<td>Browser replay inspection for behavior and failure analysis</td>
</tr>
<tr>
<td>Historical comparison</td>
<td><a href="src/bots/xathis_bot.py"><code>src/bots/xathis_bot.py</code></a>, <a href="docs/reference/xathis"><code>docs/reference/xathis/</code></a></td>
<td>Partial Python reimplementation beside the preserved winning Java source</td>
</tr>
</tbody></table>
<h2>System design</h2>
<pre><code class="language-text">map + game state
       │
       ▼
priority policy
  1. continue valid standing orders
  2. protect colony growth
  3. target enemy hills
  4. collect food
  5. engage when advantageous
  6. explore unseen space
       │
       ▼
collision-safe orders ──► engine / sandbox ──► replay + result artifacts
                                      │
                                      └──────► benchmark aggregation
</code></pre>
<p>This is a rule-based game agent, not a trained language model or reinforcement-
learning policy. The repository does include a reward-design analysis for a
possible learned successor, but that document is a design exercise rather than
implemented RL behavior.</p>
<h2>Evaluation contract</h2>
<p>The project supports three useful levels of evidence:</p>
<ol>
<li><code>make pytest</code> checks deterministic components and structural contracts.</li>
<li><code>make test</code> runs a real 30-turn game through the local engine.</li>
<li>Benchmark targets run repeated matches against named reference opponents and
emit machine-readable results for analysis.</li>
</ol>
<pre><code class="language-bash">make pytest
make test
make test-vs-xathis
make benchmark-xathis
</code></pre>
<p>Reproducing an engine run requires two independent values. <code>engine_seed</code>
controls engine-side randomness such as food generation; <code>player_seed</code> is sent
to each bot so opponents with randomized policies can reproduce their choices.
The showcased Make targets default to <code>SEED=42</code>: game targets pass it as both
values, while the benchmark runner uses it as a recorded master seed from which
it derives and records an engine/player seed pair for every game. Override it
with a command such as <code>make benchmark SEED=73</code>. The same code revision, map,
arguments, bot revisions, and both per-game seeds are required for a repeatable
comparison. Wall-clock timeouts and runtime differences remain external
sources of variation.</p>
<p><a href="statistics.json"><code>statistics.json</code></a> and
<a href="parallel_statistics.json"><code>parallel_statistics.json</code></a> are retained historical
runs, not a current leaderboard. They were produced at different times and do
not establish a general win-rate claim. A publishable comparison should record
the code revision, map set, seeds, turn limit, opponent revision, raw results,
and aggregation command in the same evidence bundle.</p>
<h2>Local setup</h2>
<p>The canonical environment uses <a href="https://docs.astral.sh/uv/"><code>uv</code></a>:</p>
<pre><code class="language-bash">git clone https://github.com/T-Py-T/ants-strategy-agent.git
cd ants-strategy-agent
uv sync --all-extras

make pytest
make test
make visualize-latest
</code></pre>
<p>Optional dependency groups are explicit so a contributor can install only the
surface being exercised:</p>
<table>
<thead>
<tr>
<th>Extra</th>
<th>Contents</th>
<th>Use</th>
</tr>
</thead>
<tbody><tr>
<td><code>[test]</code></td>
<td>pytest and coverage support</td>
<td>Unit and integration regression checks</td>
</tr>
<tr>
<td><code>[analysis]</code></td>
<td>pandas, NumPy, SciPy, Matplotlib, and Seaborn</td>
<td>Benchmark aggregation and plots</td>
</tr>
<tr>
<td><code>[dev]</code></td>
<td>Both groups</td>
<td>Complete contributor environment</td>
</tr>
</tbody></table>
<p>Docker and a VS Code dev container are available when a host-local Python/Java
toolchain is undesirable:</p>
<pre><code class="language-bash">make docker-build
make docker-test
</code></pre>
<p>The hosted workflow is intentionally a pull-request merge gate. Routine branch
pushes do not consume GitHub Actions minutes; agents are expected to run the
same checks locally before opening or updating a PR.</p>
<h2>Project Structure</h2>
<pre><code>src/
├── ants/               # engine, game state, protocol, sandbox
├── bots/               # strategy bot and partial Xathis reimplementation
├── sample_bots/        # fixed evaluation opponents in several languages
└── tools/              # match runner and map generation
tests/                  # deterministic regression suite
scripts/                # benchmark and analysis entry points
visualizer/             # replay viewer
maps/                   # retained evaluation maps
docs/reference/xathis/  # preserved historical reference source
</code></pre>
<h2>Scope and provenance</h2>
<p>Taylor&#39;s work includes the strategy implementation, partial Python Xathis
reimplementation, integration hardening, tests, benchmark/analysis tooling,
and developer workflow around the challenge. The repository also preserves
challenge-engine, sample-opponent, visualizer, and historical Xathis reference
material so the system can be exercised locally. Those retained components are
reference and compatibility inputs, not presented as original work; see
<a href="docs/gitroll-triage.md"><code>docs/gitroll-triage.md</code></a> for the explicit maintenance
boundary.</p>
<p>The preserved Java sources under <code>docs/reference/xathis/</code> are the historical
first-place Xathis bot. <code>src/bots/xathis_bot.py</code> is an incomplete Python
reimplementation: several strategy phases remain no-ops, and its combat search
is a simplified, bounded substitute for the original algorithm. Its tests show
that the implemented pieces and engine integration work; they do not establish
strategic fidelity or strength equivalent to the winning Java bot. Xathis
matchups in this repository are therefore regression and comparison inputs,
not evidence of world-class competitive performance.</p>
<p>The repository does not currently publish a repository-wide license file.
Third-party source remains subject to its original terms and retained notices.</p>
</article>
</body>
</html>
```
</details>
<details>
<summary>Evidence: Recruiter-facing command menu</summary>

```text
ants-strategy-agent testing commands:

Setup:
  install          Install all Python dependencies (prefers uv, falls back to pip)
  install-uv       Install uv itself if not already on PATH
  docker-build     Build Docker image for testing

Unit tests:
  pytest           Run the full unit-test suite (recommended pre-commit gate)
  pytest-quick     Run only fast unit tests (skip subprocess-bot tests)
  pytest-coverage  Run pytest with coverage report

Integration testing:
  test             Run quick game (30 turns, 2 players)
  test-quick       Run quick game with your bot vs random
  test-full        Run full game (1000 turns, 4 players)
  test-self        Test your bot against itself (4 players)
  test-against-samples  Test against all sample bots
  test-probabilistic   Run 10 games per opponent, calculate win rates
  test-against-random   Test against RandomBot
  test-against-hunter   Test against HunterBot
  test-against-greedy   Test against GreedyBot
  test-against-lefty    Test against LeftyBot
  test-vs-xathis        Test against the partial Xathis reimplementation

Statistical Analysis:
  stats            Run statistical analysis (default: 10 games, 1000 turns)
  stats-json       Run JSON-based statistical analysis (default: 10 games, 1000 turns)
  stats-parallel   Run parallel statistical analysis (default: 100 games, 10 parallel)
  stats GAMES=5 TURNS=500    Run with custom parameters
  stats-json GAMES=20 TURNS=2000  Run JSON analysis with custom parameters
  stats-parallel GAMES=500 PARALLEL=20  Run parallel analysis with custom parameters

Analysis:
  analyze            Fast analysis (20 games + stats)
  validate           Validate raw outputs against fast analysis

Visualization:
  test-visualize   Run test with live visualization
  visualize-latest Visualize the most recent game replay

Docker:
  docker-test      Run tests in Docker container
  docker-run       Run interactive Docker container

Cleanup:
  clean            Clean game logs and temporary files
```
</details>
<details>
<summary>Evidence: Seeded engine run 1</summary>

```text
Running quick test (30 turns, 2 players)...
PYTHONPATH=. python3 src/tools/playgame.py \
		--engine_seed 42 \
		--player_seed 42 \
		--end_wait=0.25 \
		--verbose \
		--log_dir game_logs \
		--turns 30 \
		--map_file maps/maze/maze_02p_01.map \
		"python3 src/bots/bot.py" \
		"python3 src/sample_bots/python/RandomBot.py"
running for 30 turns
                  ant_count c_turns climb? cutoff food r_turn ranking_bots s_alive s_hills score  w_turn winning
turn    0 stats:   [1,1,0]     0    [1,1]    -     40    0        None      [1,1]   [1,1]  [1,1]   0     None  
turn    1 stats:   [1,1,0]     1    [1,1]   Food   40    1       [0,0]      [1,1]   [1,1]  [1,1]   1     [0,1] 
turn    2 stats:   [1,1,0]     2    [1,1]   Food   40    1       [0,0]      [1,1]   [1,1]  [1,1]   1     [0,1] 
turn    3 stats:   [1,1,0]     3    [1,1]   Food   41    1       [0,0]      [1,1]   [1,1]  [1,1]   1     [0,1] 
turn    4 stats:   [2,1,0]     4    [1,1]   Food   41    1       [0,0]      [1,1]   [1,1]  [1,1]   1     [0,1] 
turn    5 stats:   [2,1,0]     5    [1,1]   Food   43    1       [0,0]      [1,1]   [1,1]  [1,1]   1     [0,1] 
turn    6 stats:   [2,1,0]     6    [1,1]   Food   43    1       [0,0]      [1,1]   [1,1]  [1,1]   1     [0,1] 
turn    7 stats:   [2,1,0]     7    [1,1]   Food   45    1       [0,0]      [1,1]   [1,1]  [1,1]   1     [0,1] 
turn    8 stats:   [2,1,0]     8    [1,1]   Food   45    1       [0,0]      [1,1]   [1,1]  [1,1]   1     [0,1] 
turn    9 stats:   [2,1,0]     9    [1,1]   Food   47    1       [0,0]      [1,1]   [1,1]  [1,1]   1     [0,1] 
turn   10 stats:   [2,1,0]    10    [1,1]   Food   46    1       [0,0]      [1,1]   [1,1]  [1,1]   1     [0,1] 
turn   11 stats:   [3,1,0]    11    [1,1]   Food   48    1       [0,0]      [1,1]   [1,1]  [1,1]   1     [0,1] 
turn   12 stats:   [3,1,0]    12    [1,1]   Food   47    1       [0,0]      [1,1]   [1,1]  [1,1]   1     [0,1] 
turn   13 stats:   [4,1,0]    13    [1,1]   Food   47    1       [0,0]      [1,1]   [1,1]  [1,1]   1     [0,1] 
turn   14 stats:   [4,1,0]    14    [1,1]   Food   46    1       [0,0]      [1,1]   [1,1]  [1,1]   1     [0,1] 
turn   15 stats:   [5,1,0]    15    [1,1]   Food   46    1       [0,0]      [1,1]   [1,1]  [1,1]   1     [0,1] 
turn   16 stats:   [5,1,0]    16    [1,1]   Food   48    1       [0,0]      [1,1]   [1,1]  [1,1]   1     [0,1] 
turn   17 stats:   [5,1,0]    17    [1,1]   Food   48    1       [0,0]      [1,1]   [1,1]  [1,1]   1     [0,1] 
turn   18 stats:   [5,1,0]    18    [1,1]   Food   50    1       [0,0]      [1,1]   [1,1]  [1,1]   1     [0,1] 
turn   19 stats:   [5,1,0]    19    [1,1]   Food   50    1       [0,0]      [1,1]   [1,1]  [1,1]   1     [0,1] 
turn   20 stats:   [5,1,0]    20    [1,1]   Food   52    1       [0,0]      [1,1]   [1,1]  [1,1]   1     [0,1] 
turn   21 stats:   [5,1,0]    21    [1,1]   Food   51    1       [0,0]      [1,1]   [1,1]  [1,1]   1     [0,1] 
turn   22 stats:   [5,2,0]    22    [1,1]   Food   53    1       [0,0]      [1,1]   [1,1]  [1,1]   1     [0,1] 
turn   23 stats:   [5,2,0]    23    [1,1]   Food   53    1       [0,0]      [1,1]   [1,1]  [1,1]   1     [0,1] 
turn   24 stats:   [5,2,0]    24    [1,1]   Food   53    1       [0,0]      [1,1]   [1,1]  [1,1]   1     [0,1] 
turn   25 stats:   [5,2,0]    25    [1,1]   Food   55    1       [0,0]      [1,1]   [1,1]  [1,1]   1     [0,1] 
turn   26 stats:   [5,2,0]    26    [1,1]   Food   55    1       [0,0]      [1,1]   [1,1]  [1,1]   1     [0,1] 
turn   27 stats:   [5,2,0]    27    [1,1]   Food   57    1       [0,0]      [1,1]   [1,1]  [1,1]   1     [0,1] 
turn   28 stats:   [5,2,0]    28    [1,1]   Food   57    1       [0,0]      [1,1]   [1,1]  [1,1]   1     [0,1] 
turn   29 stats:   [5,2,0]    29    [1,1]   Food   57    1       [0,0]      [1,1]   [1,1]  [1,1]   1     [0,1] 
turn   30 stats:   [5,2,0]    30    [1,1]   Food   57    1       [0,0]      [1,1]   [1,1]  [1,1]   1     [0,1] 
score 1 1
status survived survived
playerturns 30 30
waiting 0.25 seconds for bots to process end turn
RESULT game_id=0 turns=30 winner=tie(player_0,player_1) player_0=bot.py:rank=0,score=1,status=survived player_1=RandomBot.py:rank=0,score=1,status=survived
```
</details>
<details>
<summary>Evidence: Seeded engine run 2</summary>

```text
Running quick test (30 turns, 2 players)...
PYTHONPATH=. python3 src/tools/playgame.py \
		--engine_seed 42 \
		--player_seed 42 \
		--end_wait=0.25 \
		--verbose \
		--log_dir game_logs \
		--turns 30 \
		--map_file maps/maze/maze_02p_01.map \
		"python3 src/bots/bot.py" \
		"python3 src/sample_bots/python/RandomBot.py"
running for 30 turns
                  ant_count c_turns climb? cutoff food r_turn ranking_bots s_alive s_hills score  w_turn winning
turn    0 stats:   [1,1,0]     0    [1,1]    -     40    0        None      [1,1]   [1,1]  [1,1]   0     None  
turn    1 stats:   [1,1,0]     1    [1,1]   Food   40    1       [0,0]      [1,1]   [1,1]  [1,1]   1     [0,1] 
turn    2 stats:   [1,1,0]     2    [1,1]   Food   40    1       [0,0]      [1,1]   [1,1]  [1,1]   1     [0,1] 
turn    3 stats:   [1,1,0]     3    [1,1]   Food   41    1       [0,0]      [1,1]   [1,1]  [1,1]   1     [0,1] 
turn    4 stats:   [2,1,0]     4    [1,1]   Food   41    1       [0,0]      [1,1]   [1,1]  [1,1]   1     [0,1] 
turn    5 stats:   [2,1,0]     5    [1,1]   Food   43    1       [0,0]      [1,1]   [1,1]  [1,1]   1     [0,1] 
turn    6 stats:   [2,1,0]     6    [1,1]   Food   43    1       [0,0]      [1,1]   [1,1]  [1,1]   1     [0,1] 
turn    7 stats:   [2,1,0]     7    [1,1]   Food   45    1       [0,0]      [1,1]   [1,1]  [1,1]   1     [0,1] 
turn    8 stats:   [2,1,0]     8    [1,1]   Food   45    1       [0,0]      [1,1]   [1,1]  [1,1]   1     [0,1] 
turn    9 stats:   [2,1,0]     9    [1,1]   Food   47    1       [0,0]      [1,1]   [1,1]  [1,1]   1     [0,1] 
turn   10 stats:   [2,1,0]    10    [1,1]   Food   46    1       [0,0]      [1,1]   [1,1]  [1,1]   1     [0,1] 
turn   11 stats:   [3,1,0]    11    [1,1]   Food   48    1       [0,0]      [1,1]   [1,1]  [1,1]   1     [0,1] 
turn   12 stats:   [3,1,0]    12    [1,1]   Food   47    1       [0,0]      [1,1]   [1,1]  [1,1]   1     [0,1] 
turn   13 stats:   [4,1,0]    13    [1,1]   Food   47    1       [0,0]      [1,1]   [1,1]  [1,1]   1     [0,1] 
turn   14 stats:   [4,1,0]    14    [1,1]   Food   46    1       [0,0]      [1,1]   [1,1]  [1,1]   1     [0,1] 
turn   15 stats:   [5,1,0]    15    [1,1]   Food   46    1       [0,0]      [1,1]   [1,1]  [1,1]   1     [0,1] 
turn   16 stats:   [5,1,0]    16    [1,1]   Food   48    1       [0,0]      [1,1]   [1,1]  [1,1]   1     [0,1] 
turn   17 stats:   [5,1,0]    17    [1,1]   Food   48    1       [0,0]      [1,1]   [1,1]  [1,1]   1     [0,1] 
turn   18 stats:   [5,1,0]    18    [1,1]   Food   50    1       [0,0]      [1,1]   [1,1]  [1,1]   1     [0,1] 
turn   19 stats:   [5,1,0]    19    [1,1]   Food   50    1       [0,0]      [1,1]   [1,1]  [1,1]   1     [0,1] 
turn   20 stats:   [5,1,0]    20    [1,1]   Food   52    1       [0,0]      [1,1]   [1,1]  [1,1]   1     [0,1] 
turn   21 stats:   [5,1,0]    21    [1,1]   Food   51    1       [0,0]      [1,1]   [1,1]  [1,1]   1     [0,1] 
turn   22 stats:   [5,2,0]    22    [1,1]   Food   53    1       [0,0]      [1,1]   [1,1]  [1,1]   1     [0,1] 
turn   23 stats:   [5,2,0]    23    [1,1]   Food   53    1       [0,0]      [1,1]   [1,1]  [1,1]   1     [0,1] 
turn   24 stats:   [5,2,0]    24    [1,1]   Food   53    1       [0,0]      [1,1]   [1,1]  [1,1]   1     [0,1] 
turn   25 stats:   [5,2,0]    25    [1,1]   Food   55    1       [0,0]      [1,1]   [1,1]  [1,1]   1     [0,1] 
turn   26 stats:   [5,2,0]    26    [1,1]   Food   55    1       [0,0]      [1,1]   [1,1]  [1,1]   1     [0,1] 
turn   27 stats:   [5,2,0]    27    [1,1]   Food   57    1       [0,0]      [1,1]   [1,1]  [1,1]   1     [0,1] 
turn   28 stats:   [5,2,0]    28    [1,1]   Food   57    1       [0,0]      [1,1]   [1,1]  [1,1]   1     [0,1] 
turn   29 stats:   [5,2,0]    29    [1,1]   Food   57    1       [0,0]      [1,1]   [1,1]  [1,1]   1     [0,1] 
turn   30 stats:   [5,2,0]    30    [1,1]   Food   57    1       [0,0]      [1,1]   [1,1]  [1,1]   1     [0,1] 
score 1 1
status survived survived
playerturns 30 30
waiting 0.25 seconds for bots to process end turn
RESULT game_id=0 turns=30 winner=tie(player_0,player_1) player_0=bot.py:rank=0,score=1,status=survived player_1=RandomBot.py:rank=0,score=1,status=survived
```
</details>
<details>
<summary>Evidence: Successful seeded benchmark</summary>

```text
ants-strategy-agent benchmark suite
===================================
Bot under test : src/bots/bot.py
Games/matchup  : 1
Turn limit     : 30
Master seed    : 42
2P map         : maps/maze/maze_02p_01.map
4P map         : maps/maze/maze_04p_01.map

[matchup] vs_RandomBot  (1 games on maze_02p_01.map)
  game 1/1   DRAW  turns=30    scores=[1,1]  status=[survived,survived]  (1.50s)
  → 0 wins / 0 losses / 1 draws / 0 errors  win_rate=0%  avg_turns=30

[matchup] vs_HoldBot  (1 games on maze_02p_01.map)
  game 1/1   DRAW  turns=30    scores=[1,1]  status=[survived,survived]  (1.57s)
  → 0 wins / 0 losses / 1 draws / 0 errors  win_rate=0%  avg_turns=30

[matchup] vs_HunterBot  (1 games on maze_02p_01.map)
  game 1/1   DRAW  turns=30    scores=[1,1]  status=[survived,survived]  (1.50s)
  → 0 wins / 0 losses / 1 draws / 0 errors  win_rate=0%  avg_turns=30

[matchup] vs_GreedyBot  (1 games on maze_02p_01.map)
  game 1/1   DRAW  turns=30    scores=[1,1]  status=[survived,survived]  (1.51s)
  → 0 wins / 0 losses / 1 draws / 0 errors  win_rate=0%  avg_turns=30

[matchup] vs_LeftyBot  (1 games on maze_02p_01.map)
  game 1/1   DRAW  turns=30    scores=[1,1]  status=[survived,survived]  (1.31s)
  → 0 wins / 0 losses / 1 draws / 0 errors  win_rate=0%  avg_turns=30

[matchup] vs_XathisBot  (1 games on maze_02p_01.map)
  game 1/1   DRAW  turns=30    scores=[1,1]  status=[survived,survived]  (1.56s)
  → 0 wins / 0 losses / 1 draws / 0 errors  win_rate=0%  avg_turns=30

[matchup] Four_Player  (1 games on maze_04p_01.map)
  game 1/1   DRAW  turns=30    scores=[1,1,1,1]  status=[survived,survived,survived,survived]  (1.36s)
  → 0 wins / 0 losses / 1 draws / 0 errors  win_rate=0%  avg_turns=30

Summary written to /var/folders/56/9gldf4zd5l526h1c7r293fzr0000gn/T/no-mistakes-evidence/01M0HC1DWTSJH09YMQ2DP32B6E/benchmark-fixed-results/summary_2026-08-21_01-35-22.md
Overall: 0/7 wins (0%)
```
</details>
<details>
<summary>Evidence: Benchmark Markdown summary</summary>

```text
# ants-strategy-agent benchmark summary

Generated: 2026-08-21_01-35-22
Master seed: 42

| Matchup | Wins | Losses | Draws | Errors | Win % | Avg turns | Avg time |
|---|---:|---:|---:|---:|---:|---:|---:|
| vs_RandomBot | 0 | 0 | 1 | 0 | 0% | 30 | 1.5s |
| vs_HoldBot | 0 | 0 | 1 | 0 | 0% | 30 | 1.6s |
| vs_HunterBot | 0 | 0 | 1 | 0 | 0% | 30 | 1.5s |
| vs_GreedyBot | 0 | 0 | 1 | 0 | 0% | 30 | 1.5s |
| vs_LeftyBot | 0 | 0 | 1 | 0 | 0% | 30 | 1.3s |
| vs_XathisBot | 0 | 0 | 1 | 0 | 0% | 30 | 1.6s |
| Four_Player | 0 | 0 | 1 | 0 | 0% | 30 | 1.4s |
```
</details>
- Evidence: Benchmark JSON with seed provenance (local file: <code>/var/folders/56/9gldf4zd5l526h1c7r293fzr0000gn/T/no-mistakes-evidence/01M0HC1DWTSJH09YMQ2DP32B6E/benchmark-fixed-results/summary_2026-08-21_01-35-22.json</code>)
<details>
<summary>Evidence: Determinism comparison</summary>

`Two independent seed-42 benchmark runs matched on every matchup, derived engine/player seed, player record, winner, outcome, and turn count.`

```text
MATCH: two independent benchmark runs have identical seeded game contracts
vs_RandomBot: master=42 engine=670488 player=116740 turns=30 winner=tie(player_0,player_1) outcome=DRAW
vs_HoldBot: master=42 engine=26226 player=777573 turns=30 winner=tie(player_0,player_1) outcome=DRAW
vs_HunterBot: master=42 engine=288390 player=256788 turns=30 winner=tie(player_0,player_1) outcome=DRAW
vs_GreedyBot: master=42 engine=234054 player=146317 turns=30 winner=tie(player_0,player_1) outcome=DRAW
vs_LeftyBot: master=42 engine=772247 player=107474 turns=30 winner=tie(player_0,player_1) outcome=DRAW
vs_XathisBot: master=42 engine=709571 player=776647 turns=30 winner=tie(player_0,player_1) outcome=DRAW
Four_Player: master=42 engine=935519 player=571859 turns=30 winner=tie(player_0,player_1,player_2,player_3) outcome=DRAW
```
</details>
<details>
<summary>Evidence: CI trigger contract</summary>

`PASS: CI is pull-request-only; no push trigger is configured.`

```text
PASS: CI is pull-request-only; no push trigger is configured.
  pull_request:
    branches: [main]
    types: [opened, synchronize, reopened, ready_for_review]
```
</details>
<details>
<summary>Evidence: Current GitHub pin verification</summary>

Source: [Current GitHub pin verification](https://github.com/T-Py-T)

`Live pinned repositories include ants-strategy-agent.`

```text
nix-homelab
ants-strategy-agent
kubernetes-gitops-homelab
gta5-vision-driving-agent
starcraft2-ppo-agent
trading-platform-orchestration
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed ✅</summary>

- 🚨 `README.md:1` - The required criterion is “rename and reframe it as ants-strategy-agent,” but the new heading is not carried through recruiter-visible workflows: `Makefile:8`, `scripts/benchmark.py:226,255,307`, and `.devcontainer/devcontainer.json:2` still display “AntsAIBot.” Confirm whether these may remain for compatibility; otherwise complete the user-facing rename.
- 🚨 `README.md:7` - The required criterion is to “explain its deterministic engine [and] evaluation contract,” but the README promises repeatable matches while showcasing `test-vs-xathis` and benchmark commands that pass only `--player_seed`. When `engine_seed` is omitted, `src/ants/ants.py:51` generates one randomly, so even `benchmark.py --seed` is not reproducible. Document the two-seed invariant and either propagate an engine seed through `scripts/benchmark.py::run_one_game` and the showcased Make target, or narrow the repeatability claim.
- 🚨 `README.md:20` - The required criterion calls for “provenance and honest limitations,” but this hunk describes Xathis as a “Strong reference opponent” and “Tested Python port.” The referenced implementation declares itself “V1: scaffolding only,” contains multiple TODO/no-op strategy phases, and uses a simplified capped combat search. Distinguish the preserved original winning Java bot from the partial Python reimplementation rather than implying equivalent completeness or strength.

🔧 Fix: Complete rebrand, deterministic benchmarks, and honest Xathis framing
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected `ac42e8c5666e71460837e6cb06867312929a7e3b..8b59c9296b3af943cc0ca848a65c4dba35fedc78` against the show-ready acceptance criteria.</code>
- `.venv/bin/pytest -q tests/test_benchmark_parser.py tests/test_playgame_result_line.py tests/test_readme_consistency.py tests/test_analyze_results.py tests/test_devcontainer.py tests/test_advanced_bot.py`
- <code>`make test SEED=42` twice; both runs emitted the identical 30-turn `RESULT` contract.</code>
- <code>`python3 scripts/benchmark.py --games 1 --turns 30 --seed 42` with absolute evidence log/output directories; the first run exposed the path-reporting defect and the post-fix rerun completed all seven matchups.</code>
- <code>`.venv/bin/pytest -q tests/test_benchmark_parser.py` after adding `test_main_reports_summary_outside_repo`.</code>
- `Compared two independent benchmark JSON outputs after excluding wall-clock duration; seeded contracts matched exactly.`
- <code>`make help` and repository-wide stale-brand inspection verified the renamed public CLI and honest partial-Xathis wording.</code>
- <code>Manually asserted `.github/workflows/ci.yml` contains `pull_request` and no `push` trigger.</code>
- <code>Rendered `README.md` into a self-contained GitHub-style HTML artifact; screenshot capture was attempted, but no active browser remained available.</code>
- <code>Fetched the live public GitHub profile and confirmed `ants-strategy-agent` remains pinned.</code>
- <code>Verified `portfolio/show-ready` points at the tested HEAD and removed generated replay files from the worktree.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
